### PR TITLE
Implement `ping` request handling

### DIFF
--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -126,6 +126,27 @@ function handle_initialize(ctx::RequestContext, params::InitializeParams)::Handl
 end
 
 """
+    handle_ping(ctx::RequestContext, params::Nothing) -> HandlerResult
+
+Handle MCP protocol ping requests.
+
+# Arguments
+- `ctx::RequestContext`: The current request context
+- `params::Nothing`: The ping parameters does not contain any data
+
+# Returns
+- `HandlerResult`: Ping returns an empty response payload
+"""
+function handle_ping(ctx::RequestContext, ::Nothing)::HandlerResult
+    HandlerResult(
+        response=JSONRPCResponse(
+            id=ctx.request_id,
+            result=Dict{String,Any}()
+        )
+    )
+end
+
+"""
     handle_list_prompts(ctx::RequestContext, params::ListPromptsParams) -> HandlerResult
 
 Handle requests to list available prompts on the MCP server.
@@ -628,6 +649,8 @@ function handle_request(server::Server, request::Request)::Response
         result =
             if request.method == "initialize"
                 handle_initialize(ctx, request.params::InitializeParams)
+            elseif request.method == "ping"
+                handle_ping(ctx, request.params::Nothing)
             elseif request.method == "resources/list"
                 handle_list_resources(ctx, request.params::ListResourcesParams)
             elseif request.method == "resources/read"

--- a/src/protocol/messages.jl
+++ b/src/protocol/messages.jl
@@ -301,7 +301,7 @@ JSON-RPC request message used to invoke methods on the server.
 Base.@kwdef struct JSONRPCRequest <: Request
     id::RequestId
     method::String
-    params::Union{RequestParams, Nothing}
+    params::Union{RequestParams, Nothing} = nothing
     meta::RequestMeta = RequestMeta()
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using ModelContextProtocol
-using ModelContextProtocol: handle_initialize, handle_read_resource, handle_list_resources, handle_get_prompt
+using ModelContextProtocol: handle_initialize, handle_read_resource, handle_list_resources, handle_get_prompt, handle_ping
 using JSON3, URIs, DataStructures
 using Logging
 
@@ -113,6 +113,14 @@ const TEST_TOOL = MCPTool(
         result = handle_list_resources(ctx, list_params)
         @test result isa HandlerResult
         @test !isnothing(result.response)
+
+        # Ping requests
+        ctx = RequestContext(server=server, request_id=2)
+        result = handle_ping(ctx, nothing)
+        @test result isa HandlerResult
+        @test !isnothing(result.response)
+        @test result.response.id == 2
+        @test isempty(result.response.result)
     end
 
     @testset "Template Processing" begin


### PR DESCRIPTION
As defined in https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/utilities/ping/, 
this one seemed like some nice low-hanging fruit to implement. I have confirmed it works using the inspector `npx @modelcontextprotocol/inspector`. `ping` parameter body should be empty, and the response should contain no payload by my reading of the spec.
