### PR TITLE
Avoid reparsing request parameters

### DIFF
--- a/src/protocol/jsonrpc.jl
+++ b/src/protocol/jsonrpc.jl
@@ -131,7 +131,7 @@ function parse_request(raw::JSON3.Object)::Request
         if isempty(raw.params)
             params_type()  # Construct default instance instead of nothing
         else
-            JSON3.read(JSON3.write(raw.params), params_type)
+            StructTypes.constructfrom(params_type, raw.params)
         end
     else
         nothing


### PR DESCRIPTION
To avoid the `JSON3.read(JSON3.write` pattern instead use `StructTypes.constructfrom` to convert the raw params into the final type. I believe this should cover all the types that this will encounter.

Appears to improve message parsing time somewhat:

```
julia> init_req = """
       {
           "jsonrpc": "2.0",
           "id": 1,
           "method": "initialize",
           "params": {
               "capabilities": {},
               "clientInfo": {"name": "test", "version": "1.0"},
               "protocolVersion": "1.0"
           }
       }
       """;

julia> @b ModelContextProtocol.parse_message(init_req) # before
10.062 μs (122 allocs: 8.500 KiB)

julia> @b ModelContextProtocol.parse_message(init_req) # after
4.608 μs (66 allocs: 6.469 KiB)

```