### PR TITLE
fix: Correct protocol version negotiation per MCP spec

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelContextProtocol"
 uuid = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
 authors = ["klidke@unm.edu"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -126,28 +126,15 @@ Handle MCP protocol initialization requests by setting up the server and returni
 - `HandlerResult`: Contains the server's capabilities and configuration
 """
 function handle_initialize(ctx::RequestContext, params::InitializeParams)::HandlerResult
-    # Currently we only support MCP protocol version 2025-06-18
-    # In the future, this could be extended to support multiple versions
-    SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18"]
-    supported_version = SUPPORTED_PROTOCOL_VERSIONS[1]  # Use the only supported version for now
-    
-    # Check if client requested a specific version
-    if !isnothing(params.protocolVersion) && params.protocolVersion != supported_version
-        # Return error for unsupported versions
-        error_info = ErrorInfo(
-            code = ErrorCodes.INVALID_PARAMS,
-            message = "Unsupported protocol version",
-            data = LittleDict{String,Any}(
-                "supported" => [supported_version],
-                "requested" => params.protocolVersion
-            )
-        )
-        return HandlerResult(
-            response=JSONRPCError(
-                id=ctx.request_id,
-                error=error_info
-            )
-        )
+    # MCP protocol version we support
+    # Per spec: if client requests unsupported version, server MUST respond with
+    # a version it supports (not error). Client then decides if it can work with that.
+    SERVER_PROTOCOL_VERSION = "2025-06-18"
+
+    # Log version negotiation for debugging
+    client_version = params.protocolVersion
+    if !isnothing(client_version) && client_version != SERVER_PROTOCOL_VERSION
+        @debug "Version negotiation" client_requested=client_version server_supports=SERVER_PROTOCOL_VERSION
     end
 
     # Get full capabilities including available tools and resources
@@ -163,7 +150,7 @@ function handle_initialize(ctx::RequestContext, params::InitializeParams)::Handl
             "version" => ctx.server.config.version
         ),
         capabilities=current_capabilities,
-        protocolVersion=supported_version,
+        protocolVersion=SERVER_PROTOCOL_VERSION,
         instructions=ctx.server.config.instructions
     )
 

--- a/src/transports/http.jl
+++ b/src/transports/http.jl
@@ -302,28 +302,13 @@ function handle_request(transport::HttpTransport, stream::HTTP.Stream)
         return nothing
     end
     
-    # Check MCP-Protocol-Version header - required for 2025-06-18 spec
+    # MCP-Protocol-Version header check
+    # Per spec: version negotiation happens at JSON-RPC level (initialize request/response).
+    # The header is for subsequent requests after negotiation. We log mismatches but don't
+    # error - the JSON-RPC layer handles version negotiation properly.
     client_protocol_version = HTTP.header(request, "MCP-Protocol-Version", "")
     if !isempty(client_protocol_version) && client_protocol_version != transport.protocol_version
-        @debug "Unsupported protocol version" client=client_protocol_version server=transport.protocol_version
-        HTTP.setstatus(stream, 400)
-        HTTP.setheader(stream, "Content-Type" => "application/json")
-        error_response = JSON3.write(Dict(
-            "jsonrpc" => "2.0",
-            "error" => Dict(
-                "code" => -32602,
-                "message" => "Unsupported protocol version", 
-                "data" => Dict(
-                    "supported" => [transport.protocol_version],
-                    "requested" => client_protocol_version
-                )
-            ),
-            "id" => nothing
-        ))
-        HTTP.setheader(stream, "Content-Length" => string(length(error_response)))
-        HTTP.startwrite(stream)  # Ensure headers are sent
-        write(stream, error_response)
-        return nothing
+        @debug "Client protocol version differs from server" client=client_protocol_version server=transport.protocol_version
     end
     
     # Security: Validate Origin header if configured

--- a/test/transports/test_streamable_http.jl
+++ b/test/transports/test_streamable_http.jl
@@ -211,104 +211,78 @@
         Base.close(timer)
     end
     
-    @testset "Protocol Version Validation" begin
+    @testset "Protocol Version Negotiation" begin
+        # Per MCP spec: version negotiation happens at JSON-RPC level.
+        # Server MUST respond with a version it supports (not error).
+        # Client then decides if it can work with that version.
+
         port = 15090 + rand(1:1000)
-        
+
         transport = HttpTransport(port=port, protocol_version="2025-06-18")
-        
+
         server = mcp_server(
             name = "version-test",
             version = "1.0.0"
         )
-        
+
         server.transport = transport
         ModelContextProtocol.connect(transport)
-        
+
         server_task = @async start!(server)
         sleep(2)
-        
-        # First, properly initialize the server
+
+        # Test 1: Client requests newer version, server responds with its version
         init_response = HTTP.post(
             "http://127.0.0.1:$port/",
             ["Content-Type" => "application/json",
-             "MCP-Protocol-Version" => "2025-06-18",
+             "MCP-Protocol-Version" => "2025-11-25",  # Client sends newer version
              "Accept" => "application/json, text/event-stream"],
             JSON3.write(Dict(
                 "jsonrpc" => "2.0",
                 "method" => "initialize",
                 "params" => Dict(
-                    "protocolVersion" => "2025-06-18",
+                    "protocolVersion" => "2025-11-25",  # Client requests newer version
                     "capabilities" => Dict(),
                     "clientInfo" => Dict("name" => "test", "version" => "1.0")
                 ),
-                "id" => 0
+                "id" => 1
             ))
         )
         @test init_response.status == 200
+        result = JSON3.read(String(init_response.body))
+        @test haskey(result, "result")
+        # Server responds with its supported version (not error)
+        @test result["result"]["protocolVersion"] == "2025-06-18"
+
         session_id = HTTP.header(init_response, "Mcp-Session-Id", "")
-        
-        # Request with wrong protocol version header - should fail
-        try
-            response = HTTP.post(
-                "http://127.0.0.1:$port/",
-                ["Content-Type" => "application/json",
-                 "MCP-Protocol-Version" => "2024-11-05",  # Wrong version
-                 "Accept" => "application/json, text/event-stream"],
-                JSON3.write(Dict(
-                    "jsonrpc" => "2.0",
-                    "method" => "initialize",
-                    "params" => Dict(
-                        "protocolVersion" => "2025-06-18",
-                        "capabilities" => Dict(),
-                        "clientInfo" => Dict("name" => "test", "version" => "1.0")
-                    ),
-                    "id" => 1
-                ))
-            )
-            @test false  # Should not succeed
-        catch e
-            if e isa HTTP.ExceptionRequest.StatusError
-                @test e.response.status == 400  # Should return 400 for wrong protocol version
-                # Verify the error message
-                body = String(e.response.body)
-                msg = JSON3.read(body)
-                @test msg["error"]["code"] == -32602
-                @test contains(msg["error"]["message"], "protocol version")
-            else
-                rethrow(e)
-            end
-        end
-        
-        # Request with wrong protocol version in params (but correct header)
-        # This is a different case - the transport accepts it but the server should reject
+
+        # Test 2: Client requests older version, server still responds with its version
         response = HTTP.post(
             "http://127.0.0.1:$port/",
             ["Content-Type" => "application/json",
-             "MCP-Protocol-Version" => "2025-06-18",
-             "Mcp-Session-Id" => session_id,
+             "MCP-Protocol-Version" => "2024-11-05",  # Older version header
              "Accept" => "application/json, text/event-stream"],
             JSON3.write(Dict(
                 "jsonrpc" => "2.0",
                 "method" => "initialize",
                 "params" => Dict(
-                    "protocolVersion" => "2024-11-05",  # Wrong version
+                    "protocolVersion" => "2024-11-05",  # Older version
                     "capabilities" => Dict(),
                     "clientInfo" => Dict("name" => "test", "version" => "1.0")
                 ),
                 "id" => 2
             ))
         )
-        
-        # Should return error
-        @test response.status == 200  # Still 200 for JSON-RPC errors
+        @test response.status == 200
         result = JSON3.read(String(response.body))
-        @test haskey(result, "error")
-        @test result["error"]["code"] == -32602  # Invalid params
-        
+        @test haskey(result, "result")
+        # Server responds with its version, client decides compatibility
+        @test result["result"]["protocolVersion"] == "2025-06-18"
+
         # Clean up
         server.active = false
         ModelContextProtocol.close(transport)
-        
+
         timer = Timer(2)
         while !istaskdone(server_task) && isopen(timer)
             sleep(0.1)


### PR DESCRIPTION
## Summary

- Fix protocol version negotiation to comply with MCP specification
- Server now responds with its supported version instead of erroring on mismatch
- Enables compatibility with MCP Inspector and other clients using newer protocol versions

## Problem

Per MCP spec, when a client requests an unsupported version, the server **MUST** respond with a version it supports (not error). The client then decides if it can work with that version.

Our server was returning an error when clients requested versions other than `2025-06-18` (e.g., MCP Inspector sends `2025-11-25`), breaking compatibility.

## Changes

- `handlers.jl`: Remove error response for version mismatch, always respond with server's supported version (`2025-06-18`)
- `http.jl`: Remove 400 error for version header mismatch - version negotiation happens at JSON-RPC level
- Update tests to verify correct negotiation behavior

## Test plan

- [x] All 232 unit tests pass
- [x] MCP Inspector CLI works with all examples (`time_server.jl`, `multi_content_tool.jl`, `reg_dir.jl`)
- [x] Verified version negotiation: Inspector sends `2025-11-25` → Server responds `2025-06-18` → Inspector accepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)