### PR TITLE
feat: Negotiate MCP protocol version 2025-11-25 (split from #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-05
+
+### Added
+
+#### Protocol Version Negotiation (MCP 2025-11-25)
+- Server now advertises and negotiates the **2025-11-25** protocol version, with backward
+  compatibility for `2025-06-18`, `2025-03-26`, and `2024-11-05`.
+- New `src/protocol/versioning.jl` module providing the negotiation/feature-gating framework:
+  - `LATEST_PROTOCOL_VERSION`, `SUPPORTED_PROTOCOL_VERSIONS`, `FEATURE_VERSIONS`
+  - `negotiate_version(client_version)` — echo a supported version, else fall back to latest
+  - `supports(version, feature)` — feature gating by negotiated version
+  - `is_supported_version(version)`
+- All six symbols are exported for use in handlers and downstream code.
+
+### Changed
+
+- `handle_initialize` now responds with the **negotiated** protocol version instead of a
+  hardcoded `2025-06-18`. Clients requesting a supported version get it echoed back; unknown
+  versions fall back to `LATEST_PROTOCOL_VERSION`.
+- `HttpTransport` now defaults `protocol_version` to `LATEST_PROTOCOL_VERSION` (`2025-11-25`)
+  and accepts any version in `SUPPORTED_PROTOCOL_VERSIONS` for the `MCP-Protocol-Version` header.
+
+### Notes
+
+- This is the version-negotiation slice extracted from the larger OAuth 2.1 / 2025-11-25 work
+  (PR #27). Threading the negotiated version through `ServerState` for per-request feature
+  gating, and the OAuth authorization server, are deferred to follow-up PRs.
+
 ## [0.3.0] - 2025-11-16
 
 ### Breaking Changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelContextProtocol"
 uuid = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
 authors = ["klidke@unm.edu"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/ModelContextProtocol.jl
+++ b/src/ModelContextProtocol.jl
@@ -54,6 +54,9 @@ include("types.jl")
 # 2. Protocol Messages
 include("protocol/messages.jl")
 
+# 2b. Protocol version negotiation (dependency-free; used by transport + handlers)
+include("protocol/versioning.jl")
+
 # 3. Transport Layer
 include("transports/base.jl")
 include("transports/stdio.jl")
@@ -110,6 +113,10 @@ export
     # Advanced features
     Server,  # For type annotations in user code
     subscribe!, unsubscribe!,  # Resource subscription management
-    content2dict  # Utility for debugging/testing
+    content2dict,  # Utility for debugging/testing
+
+    # Protocol version negotiation and feature gating (MCP 2025-11-25)
+    LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS, FEATURE_VERSIONS,
+    negotiate_version, supports, is_supported_version
 
 end # module

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -126,15 +126,14 @@ Handle MCP protocol initialization requests by setting up the server and returni
 - `HandlerResult`: Contains the server's capabilities and configuration
 """
 function handle_initialize(ctx::RequestContext, params::InitializeParams)::HandlerResult
-    # MCP protocol version we support
-    # Per spec: if client requests unsupported version, server MUST respond with
-    # a version it supports (not error). Client then decides if it can work with that.
-    SERVER_PROTOCOL_VERSION = "2025-06-18"
-
-    # Log version negotiation for debugging
+    # Negotiate the protocol version per the MCP spec: if the client requests a
+    # version we support, echo it back; otherwise respond with our latest version
+    # and let the client decide whether it can proceed. See `negotiate_version`.
     client_version = params.protocolVersion
-    if !isnothing(client_version) && client_version != SERVER_PROTOCOL_VERSION
-        @debug "Version negotiation" client_requested=client_version server_supports=SERVER_PROTOCOL_VERSION
+    negotiated_version = negotiate_version(client_version)
+
+    if !isnothing(client_version) && client_version != negotiated_version
+        @debug "Version negotiation" client_requested=client_version negotiated=negotiated_version
     end
 
     # Get full capabilities including available tools and resources
@@ -143,7 +142,7 @@ function handle_initialize(ctx::RequestContext, params::InitializeParams)::Handl
         ctx.server
     )
 
-    # Create initialization result with our supported version
+    # Create initialization result with the negotiated version
     server_info = Dict{String,Any}(
         "name" => ctx.server.config.name,
         "version" => ctx.server.config.version
@@ -154,7 +153,7 @@ function handle_initialize(ctx::RequestContext, params::InitializeParams)::Handl
     result = InitializeResult(
         serverInfo=server_info,
         capabilities=current_capabilities,
-        protocolVersion=SERVER_PROTOCOL_VERSION,
+        protocolVersion=negotiated_version,
         instructions=ctx.server.config.instructions
     )
 

--- a/src/protocol/messages.jl
+++ b/src/protocol/messages.jl
@@ -54,12 +54,12 @@ Parameters for MCP protocol initialization requests.
 # Fields
 - `capabilities::ClientCapabilities`: Client capabilities being reported
 - `clientInfo::Implementation`: Information about the client implementation  
-- `protocolVersion::Union{String,Nothing}`: Version of the MCP protocol being used (must be "2025-06-18" - only supported version)
+- `protocolVersion::Union{String,Nothing}`: Version of the MCP protocol requested by the client. The server negotiates against `SUPPORTED_PROTOCOL_VERSIONS` (latest: `LATEST_PROTOCOL_VERSION`); see `negotiate_version`.
 """
 Base.@kwdef struct InitializeParams <: RequestParams
     capabilities::ClientCapabilities = ClientCapabilities()
     clientInfo::Implementation = Implementation()
-    protocolVersion::Union{String,Nothing} = nothing  # Must be "2025-06-18" if provided
+    protocolVersion::Union{String,Nothing} = nothing  # Negotiated against SUPPORTED_PROTOCOL_VERSIONS
 end
 
 """

--- a/src/protocol/versioning.jl
+++ b/src/protocol/versioning.jl
@@ -1,0 +1,116 @@
+# src/protocol/versioning.jl
+# MCP Protocol Version Management
+#
+# Handles version negotiation and feature gating based on negotiated protocol version.
+# Per MCP spec: if client requests a version we support, respond with that version.
+# Otherwise, respond with our latest version and let client decide.
+
+"""
+Latest MCP protocol version supported by this implementation.
+"""
+const LATEST_PROTOCOL_VERSION = "2025-11-25"
+
+"""
+All MCP protocol versions supported by this implementation, newest first.
+"""
+const SUPPORTED_PROTOCOL_VERSIONS = [
+    "2025-11-25",
+    "2025-06-18",
+    "2025-03-26",
+    "2024-11-05"
+]
+
+"""
+Minimum protocol version required for each feature.
+
+Features are identified by Symbol keys. The value is the minimum protocol version
+that introduced the feature. Use `supports(version, feature)` to check availability.
+
+# Features
+- `:tasks` - Experimental task tracking (SEP-1686)
+- `:sse_priming_events` - SSE priming for stream resumability (SEP-1699)
+- `:icon_metadata` - Icon metadata for tools/resources/prompts (SEP-973)
+- `:tool_calling_in_sampling` - Tool calling in sampling requests (SEP-1577)
+- `:oauth_openid_connect` - OpenID Connect discovery for OAuth (PR #797)
+- `:oauth_incremental_scope` - Incremental scope consent (SEP-835)
+- `:url_elicitation` - URL mode elicitation requests (SEP-1036)
+- `:streamable_http` - Streamable HTTP transport
+- `:resource_links` - ResourceLink content type
+"""
+const FEATURE_VERSIONS = Dict{Symbol, String}(
+    # 2025-11-25 features
+    :tasks => "2025-11-25",
+    :sse_priming_events => "2025-11-25",
+    :icon_metadata => "2025-11-25",
+    :tool_calling_in_sampling => "2025-11-25",
+    :oauth_openid_connect => "2025-11-25",
+    :oauth_incremental_scope => "2025-11-25",
+    :url_elicitation => "2025-11-25",
+
+    # 2025-06-18 features
+    :resource_links => "2025-06-18",
+
+    # 2025-03-26 features
+    :streamable_http => "2025-03-26",
+)
+
+"""
+    negotiate_version(client_version::Union{AbstractString, Nothing}) -> String
+
+Negotiate the protocol version with a client per the MCP specification.
+
+If the client requests a version we support, return that version. Otherwise, return
+our latest version and let the client decide whether it can proceed.
+
+# Arguments
+- `client_version::Union{AbstractString, Nothing}`: Protocol version requested by the client, or nothing
+
+# Returns
+- `String`: The negotiated protocol version
+"""
+function negotiate_version(client_version::Union{AbstractString, Nothing})::String
+    if !isnothing(client_version) && client_version in SUPPORTED_PROTOCOL_VERSIONS
+        return String(client_version)
+    end
+    return LATEST_PROTOCOL_VERSION
+end
+
+"""
+    supports(version::AbstractString, feature::Symbol) -> Bool
+
+Check whether a protocol version supports a specific feature.
+
+# Arguments
+- `version::AbstractString`: The negotiated protocol version
+- `feature::Symbol`: Feature identifier (see `FEATURE_VERSIONS` for available features)
+
+# Returns
+- `Bool`: true if the version supports the feature
+
+# Example
+```julia
+if supports(negotiated_version, :tasks)
+    # Include task tracking in response
+end
+```
+"""
+function supports(version::AbstractString, feature::Symbol)::Bool
+    min_version = get(FEATURE_VERSIONS, feature, nothing)
+    isnothing(min_version) && return false
+    return version >= min_version
+end
+
+"""
+    is_supported_version(version::AbstractString) -> Bool
+
+Check whether a protocol version is in our supported versions list.
+
+# Arguments
+- `version::AbstractString`: Protocol version string to check
+
+# Returns
+- `Bool`: true if we support this version
+"""
+function is_supported_version(version::AbstractString)::Bool
+    return version in SUPPORTED_PROTOCOL_VERSIONS
+end

--- a/src/transports/http.jl
+++ b/src/transports/http.jl
@@ -45,7 +45,7 @@ mutable struct HttpTransport <: Transport
         port::Int=8080, 
         endpoint::String="/",
         allowed_origins::Vector{String}=String[],
-        protocol_version::String="2025-06-18",
+        protocol_version::String=LATEST_PROTOCOL_VERSION,
         session_required::Bool=false
     )
         new(
@@ -309,12 +309,13 @@ function handle_request(transport::HttpTransport, stream::HTTP.Stream)
     end
     
     # MCP-Protocol-Version header check
-    # Per spec: version negotiation happens at JSON-RPC level (initialize request/response).
-    # The header is for subsequent requests after negotiation. We log mismatches but don't
-    # error - the JSON-RPC layer handles version negotiation properly.
+    # Per spec: version negotiation happens at the JSON-RPC level (initialize request/response).
+    # The header is for subsequent requests after negotiation. Any version in our supported
+    # set is accepted; we only log when the client sends a version we don't recognize. The
+    # JSON-RPC layer handles version negotiation properly.
     client_protocol_version = HTTP.header(request, "MCP-Protocol-Version", "")
-    if !isempty(client_protocol_version) && client_protocol_version != transport.protocol_version
-        @debug "Client protocol version differs from server" client=client_protocol_version server=transport.protocol_version
+    if !isempty(client_protocol_version) && !is_supported_version(client_protocol_version)
+        @debug "Client requested unsupported protocol version" client=client_protocol_version supported=SUPPORTED_PROTOCOL_VERSIONS
     end
     
     # Security: Validate Origin header if configured

--- a/test/protocol/test_versioning.jl
+++ b/test/protocol/test_versioning.jl
@@ -1,0 +1,100 @@
+@testset "Protocol Versioning" begin
+    @testset "Version Constants" begin
+        # LATEST_PROTOCOL_VERSION should be the newest
+        @test LATEST_PROTOCOL_VERSION == "2025-11-25"
+
+        # SUPPORTED_PROTOCOL_VERSIONS should include latest
+        @test LATEST_PROTOCOL_VERSION in SUPPORTED_PROTOCOL_VERSIONS
+
+        # Should support multiple versions
+        @test length(SUPPORTED_PROTOCOL_VERSIONS) >= 4
+        @test "2024-11-05" in SUPPORTED_PROTOCOL_VERSIONS
+        @test "2025-06-18" in SUPPORTED_PROTOCOL_VERSIONS
+
+        # Versions should be in descending order (newest first)
+        @test SUPPORTED_PROTOCOL_VERSIONS[1] == LATEST_PROTOCOL_VERSION
+    end
+
+    @testset "negotiate_version" begin
+        # Supported version returns same version
+        @test negotiate_version("2024-11-05") == "2024-11-05"
+        @test negotiate_version("2025-06-18") == "2025-06-18"
+        @test negotiate_version("2025-11-25") == "2025-11-25"
+
+        # Unknown version returns latest
+        @test negotiate_version("9999-99-99") == LATEST_PROTOCOL_VERSION
+        @test negotiate_version("2020-01-01") == LATEST_PROTOCOL_VERSION
+
+        # Nothing returns latest
+        @test negotiate_version(nothing) == LATEST_PROTOCOL_VERSION
+
+        # SubString should work (common in HTTP parsing)
+        @test negotiate_version(SubString("2024-11-05", 1, 10)) == "2024-11-05"
+    end
+
+    @testset "is_supported_version" begin
+        @test is_supported_version("2024-11-05")
+        @test is_supported_version("2025-06-18")
+        @test is_supported_version("2025-11-25")
+
+        @test !is_supported_version("9999-99-99")
+        @test !is_supported_version("2020-01-01")
+        @test !is_supported_version("")
+    end
+
+    @testset "FEATURE_VERSIONS" begin
+        # Should have known features
+        @test haskey(FEATURE_VERSIONS, :tasks)
+        @test haskey(FEATURE_VERSIONS, :sse_priming_events)
+        @test haskey(FEATURE_VERSIONS, :streamable_http)
+        @test haskey(FEATURE_VERSIONS, :resource_links)
+
+        # Features should map to versions we support
+        for (feature, version) in FEATURE_VERSIONS
+            @test is_supported_version(version)
+        end
+    end
+
+    @testset "supports" begin
+        # 2025-11-25 features
+        @test supports("2025-11-25", :tasks)
+        @test supports("2025-11-25", :sse_priming_events)
+        @test supports("2025-11-25", :icon_metadata)
+
+        # 2025-06-18 supports its features but not 2025-11-25 features
+        @test supports("2025-06-18", :resource_links)
+        @test !supports("2025-06-18", :tasks)
+        @test !supports("2025-06-18", :sse_priming_events)
+
+        # 2025-03-26 supports streamable_http
+        @test supports("2025-03-26", :streamable_http)
+        @test !supports("2025-03-26", :tasks)
+
+        # 2024-11-05 doesn't support newer features
+        @test !supports("2024-11-05", :tasks)
+        @test !supports("2024-11-05", :resource_links)
+        @test !supports("2024-11-05", :streamable_http)
+
+        # Unknown features return false
+        @test !supports("2025-11-25", :unknown_feature)
+        @test !supports("2025-11-25", :nonexistent)
+    end
+
+    @testset "Negotiated version flows into initialize response" begin
+        config = ServerConfig(name = "test-server")
+        server = Server(config)
+        state = ServerState()
+
+        # Client requesting a supported older version gets it echoed back
+        init_old = """{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"""
+        resp_old = process_message(server, state, init_old)
+        parsed_old = JSON3.read(resp_old)
+        @test parsed_old.result.protocolVersion == "2025-06-18"
+
+        # Client requesting an unknown version gets our latest
+        init_unknown = """{"jsonrpc":"2.0","method":"initialize","id":2,"params":{"protocolVersion":"1999-01-01","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"""
+        resp_unknown = process_message(server, state, init_unknown)
+        parsed_unknown = JSON3.read(resp_unknown)
+        @test parsed_unknown.result.protocolVersion == LATEST_PROTOCOL_VERSION
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ using ModelContextProtocol: MCPLogger  # For logging tests
     include("protocol/jsonrpc.jl")
     include("protocol/handlers.jl")
     include("protocol/parameters.jl")
+    include("protocol/test_versioning.jl")
     include("utils/serialization.jl")
     include("utils/logging.jl")
     include("transports/test_stdio.jl")

--- a/test/transports/test_http.jl
+++ b/test/transports/test_http.jl
@@ -373,7 +373,7 @@
         result = JSON3.read(String(response.body))
         @test result["status"] == "ok"
         @test haskey(result, "protocol_version")
-        @test result["protocol_version"] == "2025-06-18"
+        @test result["protocol_version"] == LATEST_PROTOCOL_VERSION
 
         # Also test with no Accept header at all
         response = HTTP.get("http://127.0.0.1:$port/")

--- a/test/transports/test_streamable_http.jl
+++ b/test/transports/test_streamable_http.jl
@@ -212,13 +212,13 @@
     end
     
     @testset "Protocol Version Negotiation" begin
-        # Per MCP spec: version negotiation happens at JSON-RPC level.
-        # Server MUST respond with a version it supports (not error).
-        # Client then decides if it can work with that version.
+        # Per MCP spec: version negotiation happens at the JSON-RPC level.
+        # If the client requests a version we support, the server echoes it back;
+        # otherwise it responds with its latest supported version.
 
         port = 15090 + rand(1:1000)
 
-        transport = HttpTransport(port=port, protocol_version="2025-06-18")
+        transport = HttpTransport(port=port)
 
         server = mcp_server(
             name = "version-test",
@@ -231,7 +231,7 @@
         server_task = @async start!(server)
         sleep(2)
 
-        # Test 1: Client requests newer version, server responds with its version
+        # Test 1: Client requests the latest supported version; server echoes it back
         init_response = HTTP.post(
             "http://127.0.0.1:$port/",
             ["Content-Type" => "application/json",
@@ -251,12 +251,12 @@
         @test init_response.status == 200
         result = JSON3.read(String(init_response.body))
         @test haskey(result, "result")
-        # Server responds with its supported version (not error)
-        @test result["result"]["protocolVersion"] == "2025-06-18"
+        # Server echoes back the negotiated (supported) version
+        @test result["result"]["protocolVersion"] == "2025-11-25"
 
         session_id = HTTP.header(init_response, "Mcp-Session-Id", "")
 
-        # Test 2: Client requests older version, server still responds with its version
+        # Test 2: Client requests an older but still-supported version; server echoes it
         response = HTTP.post(
             "http://127.0.0.1:$port/",
             ["Content-Type" => "application/json",
@@ -276,8 +276,8 @@
         @test response.status == 200
         result = JSON3.read(String(response.body))
         @test haskey(result, "result")
-        # Server responds with its version, client decides compatibility
-        @test result["result"]["protocolVersion"] == "2025-06-18"
+        # Server echoes back the negotiated (older, supported) version
+        @test result["result"]["protocolVersion"] == "2024-11-05"
 
         # Clean up
         server.active = false


### PR DESCRIPTION
## Summary

Bumps the server to advertise and negotiate the **MCP `2025-11-25`** protocol version, with backward compatibility for `2025-06-18`, `2025-03-26`, and `2024-11-05`.

This is the **version-negotiation slice extracted from the stalled OAuth PR #27**. That PR (7k+ LOC, currently `CONFLICTING`) bundles the negotiation framework with a ~2,800-LOC OAuth 2.1 server and was branched *before* the 0.4.1 title/icons work — so taking it wholesale would regress title/icons and drop the `MCPIcon` export. This PR applies only the negotiation delta on top of current `main`, keeping it small and conflict-free.

## What's included

- **New `src/protocol/versioning.jl`** (self-contained, no auth dependency):
  - `LATEST_PROTOCOL_VERSION` (`2025-11-25`), `SUPPORTED_PROTOCOL_VERSIONS`, `FEATURE_VERSIONS`
  - `negotiate_version(client_version)` — echo a supported version, else fall back to latest
  - `supports(version, feature)` — feature gating by negotiated version
  - `is_supported_version(version)`
  - All six symbols exported.
- **`handle_initialize`** negotiates instead of hardcoding `2025-06-18`. A supported client version is echoed back; an unknown version falls back to `LATEST_PROTOCOL_VERSION`. The 0.4.1 title/icons `serverInfo` handling is **preserved**.
- **`HttpTransport`** defaults `protocol_version` to `2025-11-25` and accepts any version in `SUPPORTED_PROTOCOL_VERSIONS` for the `MCP-Protocol-Version` header.
- Docstrings updated off the "only 2025-06-18 supported" language.
- Version bump `0.4.1` → `0.5.0` + CHANGELOG entry.

## Tests

- New `test/protocol/test_versioning.jl` (constants, `negotiate_version`, `supports`, `is_supported_version`, and an end-to-end check that the negotiated version flows into the `initialize` response).
- Updated the existing HTTP/Streamable-HTTP tests that asserted the old "server forces `2025-06-18`" behavior — they now verify real negotiation (supported client version echoed back).
- **Full suite green: 359 passed, 0 failed.**

## Deferred to follow-ups (intentionally not in this PR)

- **OAuth 2.1 authorization server** (the bulk of #27).
- **Threading the negotiated version through `ServerState`/`RequestContext`** for per-request feature gating — only needed once the first gated feature (e.g. Tasks) lands. The `supports()` framework ships here as the foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
