### PR TITLE
feat: Thread negotiated protocol version through ServerState (Wave 1)

### DIFF
--- a/examples/reg_dir_http.jl
+++ b/examples/reg_dir_http.jl
@@ -36,8 +36,7 @@ server = mcp_server(
 transport = HttpTransport(
     host = "127.0.0.1",
     port = 3004,
-    endpoint = "/",
-    protocol_version = "2025-06-18"
+    endpoint = "/"
 )
 
 # Set the transport on the server

--- a/examples/simple_http_server.jl
+++ b/examples/simple_http_server.jl
@@ -60,9 +60,10 @@ greet_tool = MCPTool(
 )
 
 # Create Streamable HTTP transport
+# protocol_version defaults to LATEST_PROTOCOL_VERSION; the server negotiates
+# down to whatever a client requests (see negotiate_version).
 transport = HttpTransport(
-    port = 3000,
-    protocol_version = "2025-06-18"  # Current MCP protocol
+    port = 3000
 )
 
 # Create server with tools

--- a/src/core/server.jl
+++ b/src/core/server.jl
@@ -70,10 +70,10 @@ function process_message(server::Server, state::ServerState, message::String)::U
     try
         if parsed isa JSONRPCRequest
             # Handle request
-            response = handle_request(server, parsed)
+            response = handle_request(server, state, parsed)
             return serialize_message(response) # Make sure to serialize the response
-        elseif parsed isa JSONRPCNotification 
-            handle_notification(RequestContext(server=server), parsed)
+        elseif parsed isa JSONRPCNotification
+            handle_notification(RequestContext(server=server, state=state), parsed)
             return nothing
         end
     catch e

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -8,18 +8,21 @@ Define base type for all request handlers.
 abstract type RequestHandler end
 
 """
-    RequestContext(; server::Server, request_id::Union{RequestId,Nothing}=nothing, 
-                 progress_token::Union{ProgressToken,Nothing}=nothing)
+    RequestContext(; server::Server, state::ServerState=ServerState(),
+                   request_id::Union{RequestId,Nothing}=nothing,
+                   progress_token::Union{ProgressToken,Nothing}=nothing)
 
 Store the current request context for MCP protocol handlers.
 
 # Fields
 - `server::Server`: The MCP server instance handling the request
+- `state::ServerState`: The persistent server state, carrying the negotiated protocol version for feature gating (see `supports`)
 - `request_id::Union{RequestId,Nothing}`: The ID of the current request (if any)
 - `progress_token::Union{ProgressToken,Nothing}`: Optional token for progress reporting
 """
 Base.@kwdef mutable struct RequestContext
     server::Server
+    state::ServerState = ServerState()
     request_id::Union{RequestId,Nothing} = nothing
     progress_token::Union{ProgressToken,Nothing} = nothing
 end
@@ -131,6 +134,9 @@ function handle_initialize(ctx::RequestContext, params::InitializeParams)::Handl
     # and let the client decide whether it can proceed. See `negotiate_version`.
     client_version = params.protocolVersion
     negotiated_version = negotiate_version(client_version)
+
+    # Persist the negotiated version so later handlers can feature-gate via supports(...)
+    ctx.state.protocol_version = negotiated_version
 
     if !isnothing(client_version) && client_version != negotiated_version
         @debug "Version negotiation" client_requested=client_version negotiated=negotiated_version
@@ -713,12 +719,13 @@ function handle_notification(ctx::RequestContext, notification::JSONRPCNotificat
 end
 
 """
-    handle_request(server::Server, request::Request) -> Response
+    handle_request(server::Server, state::ServerState, request::Request) -> Response
 
 Process an MCP protocol request and route it to the appropriate handler based on the request method.
 
 # Arguments
 - `server::Server`: The MCP server instance handling the request
+- `state::ServerState`: The persistent server state, threaded into the request context (carries the negotiated protocol version)
 - `request::Request`: The parsed JSON-RPC request to process
 
 # Behavior
@@ -738,9 +745,10 @@ Any exceptions thrown during processing are caught and converted to INTERNAL_ERR
 # Returns
 - `Response`: Either a successful response or an error response depending on the handler result
 """
-function handle_request(server::Server, request::Request)::Response
+function handle_request(server::Server, state::ServerState, request::Request)::Response
     ctx = RequestContext(
         server=server,
+        state=state,
         request_id=request.id,
         progress_token=request.meta.progress_token
     )

--- a/src/types.jl
+++ b/src/types.jl
@@ -629,14 +629,16 @@ Track the internal state of an MCP server during operation.
 - `running::Bool`: Whether the server main loop is active
 - `last_request_id::Int`: Last used request ID for server-initiated requests
 - `pending_requests::Dict{RequestId,String}`: Map of request IDs to method names
+- `protocol_version::Union{String,Nothing}`: MCP protocol version negotiated during initialization (see `negotiate_version`), or `nothing` before the client initializes
 """
 mutable struct ServerState
     initialized::Bool
     running::Bool
     last_request_id::Int
     pending_requests::Dict{RequestId, String}  # method name for each pending request
-    
-    ServerState() = new(false, false, 0, Dict())
+    protocol_version::Union{String,Nothing}    # negotiated MCP protocol version (set on initialize)
+
+    ServerState() = new(false, false, 0, Dict(), nothing)
 end
 
 # Server type moved to server_types.jl to resolve Transport dependency

--- a/src/types.jl
+++ b/src/types.jl
@@ -629,7 +629,7 @@ Track the internal state of an MCP server during operation.
 - `running::Bool`: Whether the server main loop is active
 - `last_request_id::Int`: Last used request ID for server-initiated requests
 - `pending_requests::Dict{RequestId,String}`: Map of request IDs to method names
-- `protocol_version::Union{String,Nothing}`: MCP protocol version negotiated during initialization (see `negotiate_version`), or `nothing` before the client initializes
+- `protocol_version::Union{String,Nothing}`: MCP protocol version negotiated during initialization (see `negotiate_version`), or `nothing` before the client initializes. Server-global, not data-raced: all handler execution is serialized through `run_server_loop`. As with `session_id`, the transport is single-session, so a repeat `initialize` overwrites this ("last initialize wins")
 """
 mutable struct ServerState
     initialized::Bool

--- a/test/protocol/test_versioning.jl
+++ b/test/protocol/test_versioning.jl
@@ -117,4 +117,27 @@
         process_message(server, state2, init_unknown)
         @test state2.protocol_version == LATEST_PROTOCOL_VERSION
     end
+
+    @testset "Negotiated version propagates to later request handlers" begin
+        config = ServerConfig(name = "propagation-test")
+        server = Server(config)
+        state = ServerState()
+
+        # Initialize negotiates and stores the version on the shared, persistent state
+        init = """{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"1.0"}}}"""
+        process_message(server, state, init)
+        @test state.protocol_version == "2025-06-18"
+
+        # A later request reuses the SAME state. The context built for it (exactly as
+        # handle_request threads it) carries the negotiated version, so a handler can
+        # feature-gate on it via supports(...).
+        later_ctx = RequestContext(server = server, state = state, request_id = 2)
+        @test later_ctx.state.protocol_version == "2025-06-18"
+        @test supports(later_ctx.state.protocol_version, :resource_links)   # a 2025-06-18 feature
+        @test !supports(later_ctx.state.protocol_version, :tasks)           # a 2025-11-25 feature
+
+        # Subsequent non-initialize requests on the same state do not disturb it
+        process_message(server, state, """{"jsonrpc":"2.0","method":"ping","id":3}""")
+        @test state.protocol_version == "2025-06-18"
+    end
 end

--- a/test/protocol/test_versioning.jl
+++ b/test/protocol/test_versioning.jl
@@ -97,4 +97,24 @@
         parsed_unknown = JSON3.read(resp_unknown)
         @test parsed_unknown.result.protocolVersion == LATEST_PROTOCOL_VERSION
     end
+
+    @testset "Negotiated version is stored in ServerState" begin
+        config = ServerConfig(name = "state-version-test")
+        server = Server(config)
+
+        # Before initialization the version is unset
+        state = ServerState()
+        @test isnothing(state.protocol_version)
+
+        # A supported client version is stored verbatim for later feature gating
+        init_supported = """{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"""
+        process_message(server, state, init_supported)
+        @test state.protocol_version == "2025-06-18"
+
+        # An unknown client version falls back to latest, and that is stored
+        state2 = ServerState()
+        init_unknown = """{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"1999-01-01","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"""
+        process_message(server, state2, init_unknown)
+        @test state2.protocol_version == LATEST_PROTOCOL_VERSION
+    end
 end


### PR DESCRIPTION
## Summary

Wave 1 follow-up to #38. Now that the server **negotiates** the protocol version, persist it into `ServerState` so request handlers can **feature-gate** behavior:

```julia
if supports(ctx.state.protocol_version, :tasks)
    # ... include 2025-11-25 task tracking
end
```

This is the keystone that turns the `supports()`/`FEATURE_VERSIONS` framework from "present" into "usable from handlers" — the structural rail every later 2025-11-25 feature (Tasks, progress, elicitation) hangs off.

## Changes

- **`ServerState.protocol_version`** — `Union{String,Nothing}`, `nothing` until the client initializes.
- **`RequestContext.state`** — new field, **defaulted** to a fresh `ServerState()`. The dispatch path threads the real, persistent state; the default keeps every existing construction site working (incl. ~25 in tests) — fully backward-compatible.
- **`handle_request(server, request)` → `handle_request(server, state, request)`** (single caller: `process_message`).
- **`handle_initialize`** stores the negotiated version into `ctx.state`.
- **`process_message`** threads `state` into both the request and notification contexts.

## Architecture note

There is one persistent `ServerState` per `start!`, shared via `run_server_loop` → `process_message` for **both** stdio and Streamable HTTP. HTTP is already single-session (`transport.session_id` is one value), so storing the version on `ServerState` matches the existing design — no new limitation. Per-session version tracking would only matter for a future multi-session HTTP refactor.

## Tests

- New testset: the negotiated version (both a supported version and the unknown→latest fallback) is stored in `ServerState`.
- **Full suite green: 362 passed, 0 failed.**

Builds on #38 (merged). Next on the roadmap: Wave 2 (cheap conformance — `Implementation.description`, complete `_meta`, `AudioContent`, JSON Schema 2020-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
