### PR TITLE
test: End-to-end protocol tests (local-only) + nightly CI job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,30 @@
+name: E2E
+# End-to-end protocol tests: spawn the shipped example servers as real
+# subprocesses and drive the MCP handshake as an external client. These are
+# skipped by the regular CI matrix (they pay full JIT startup per server) and
+# run here nightly, plus on demand via the Actions "Run workflow" button.
+on:
+  schedule:
+    - cron: '0 7 * * *'   # nightly at 07:00 UTC
+  workflow_dispatch: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  e2e:
+    name: End-to-end protocol tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      actions: write
+      contents: read
+    env:
+      MCP_TEST_E2E: "true"   # force the E2E suite even though CI=true on Actions
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v3
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/test/e2e/test_protocol_e2e.jl
+++ b/test/e2e/test_protocol_e2e.jl
@@ -1,0 +1,118 @@
+# test/e2e/test_protocol_e2e.jl
+#
+# End-to-end protocol tests. Unlike the in-process transport tests, these spawn
+# the SHIPPED example servers as real OS subprocesses and drive the MCP
+# `initialize` handshake exactly as an external client would (stdio pipe / HTTP).
+# This catches process-level and example-level regressions that in-process tests
+# structurally cannot — e.g. an example server hardcoding a protocol version.
+#
+# Gated by `RUN_E2E` in runtests.jl: runs locally by default, skipped on CI
+# (each spawned server pays full JIT startup). Force either way with the
+# MCP_TEST_E2E environment variable. No `using` here by convention — runtests.jl
+# provides Test, ModelContextProtocol, JSON3, and HTTP.
+
+const _E2E_REPO  = pkgdir(ModelContextProtocol)
+const _E2E_JULIA = Base.julia_cmd()
+
+# Build an initialize request for a client claiming protocol version `v`.
+_e2e_init(v) = string(
+    """{"jsonrpc":"2.0","method":"initialize",""",
+    """"params":{"protocolVersion":"$(v)","capabilities":{},""",
+    """"clientInfo":{"name":"e2e","version":"1.0"}},"id":1}""",
+)
+
+# (client-requested version => version the server must negotiate to in the response body)
+const _E2E_CASES = [
+    "2025-11-25" => "2025-11-25",             # latest, echoed back
+    "2025-06-18" => "2025-06-18",             # supported older, echoed (backward compat)
+    "1999-01-01" => LATEST_PROTOCOL_VERSION,  # unknown -> fall back to latest
+]
+
+# True if something is already serving HTTP at `url` (so we can spawn / skip cleanly).
+function _e2e_http_alive(url)
+    try
+        HTTP.get(url; status_exception=false, retry=false, connect_timeout=1, readtimeout=2)
+        return true
+    catch
+        return false
+    end
+end
+
+@testset "E2E protocol (real subprocesses)" begin
+
+    @testset "stdio negotiation — examples/time_server.jl" begin
+        script = joinpath(_E2E_REPO, "examples", "time_server.jl")
+        @test isfile(script)
+        for (requested, expected) in _E2E_CASES
+            out = read(pipeline(`$(_E2E_JULIA) --project=$(_E2E_REPO) $(script)`;
+                                stdin = IOBuffer(_e2e_init(requested) * "\n"),
+                                stderr = devnull), String)
+            resp = nothing
+            for line in split(out, '\n')
+                if occursin("\"protocolVersion\"", line)
+                    resp = JSON3.read(line)
+                    break
+                end
+            end
+            @test resp !== nothing
+            if resp !== nothing
+                @test resp.result.protocolVersion == expected
+            end
+        end
+    end
+
+    @testset "Streamable HTTP negotiation — examples/simple_http_server.jl" begin
+        port = 3000
+        url  = "http://127.0.0.1:$(port)/"
+        if _e2e_http_alive(url)
+            @warn "Port $(port) is already serving HTTP; skipping HTTP e2e test"
+        else
+            script = joinpath(_E2E_REPO, "examples", "simple_http_server.jl")
+            @test isfile(script)
+            proc = run(pipeline(`$(_E2E_JULIA) --project=$(_E2E_REPO) $(script)`;
+                                stdout = devnull, stderr = devnull); wait = false)
+            try
+                ready = false
+                for _ in 1:90
+                    if _e2e_http_alive(url)
+                        ready = true
+                        break
+                    end
+                    sleep(1)
+                end
+                @test ready
+                if ready
+                    # Health check (plain GET) reports a version we actually support
+                    health = JSON3.read(String(HTTP.get(url; status_exception=false).body))
+                    @test String(health.protocol_version) in SUPPORTED_PROTOCOL_VERSIONS
+
+                    hdrs = ["Content-Type" => "application/json",
+                            "Accept" => "application/json, text/event-stream"]
+                    session = ""
+                    for (requested, expected) in _E2E_CASES
+                        r = HTTP.post(url, hdrs, _e2e_init(requested); status_exception=false)
+                        @test r.status == 200
+                        @test JSON3.read(String(r.body)).result.protocolVersion == expected
+                        if isempty(session)
+                            session = HTTP.header(r, "Mcp-Session-Id", "")
+                        end
+                    end
+
+                    # Sanity: the server actually serves tools end-to-end over the wire
+                    lhdrs = isempty(session) ? hdrs : vcat(hdrs, ["Mcp-Session-Id" => session])
+                    tools = JSON3.read(String(HTTP.post(url, lhdrs,
+                        """{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}""";
+                        status_exception=false).body))
+                    @test haskey(tools.result, :tools)
+                end
+            finally
+                kill(proc)
+                try
+                    wait(proc)
+                catch
+                end
+            end
+        end
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,12 @@ using ModelContextProtocol: user, assistant  # For role constants
 using ModelContextProtocol: PromptCapability  # For server tests
 using ModelContextProtocol: MCPLogger  # For logging tests
 
+# End-to-end tests spawn the example servers as real subprocesses (slow JIT
+# startup), so they run locally by default and are skipped on CI. Force either
+# way with MCP_TEST_E2E. GitHub Actions sets CI=true, which Pkg.test inherits.
+const ON_CI   = get(ENV, "CI", "false") == "true"
+const RUN_E2E = get(ENV, "MCP_TEST_E2E", ON_CI ? "false" : "true") == "true"
+
 @testset "ModelContextProtocol.jl" begin
     include("core/types.jl")
     include("core/server.jl")
@@ -32,4 +38,10 @@ using ModelContextProtocol: MCPLogger  # For logging tests
     include("transports/test_http.jl")
     include("transports/test_streamable_http.jl")
     include("integration/full_server.jl")
+
+    if RUN_E2E
+        include("e2e/test_protocol_e2e.jl")
+    else
+        @info "Skipping E2E protocol tests (local-only; set MCP_TEST_E2E=true to run, e.g. in the nightly CI job)"
+    end
 end


### PR DESCRIPTION
## Summary

Adds **end-to-end protocol tests** that spawn the *shipped example servers as real subprocesses* and drive the MCP `initialize` handshake exactly as an external client would — the layer the in-process `Pkg.test()` suite structurally can't reach. (It's what caught `simple_http_server.jl` hardcoding the old protocol version during manual verification of the negotiation work.)

Tests that live outside `runtests.jl` get forgotten, so these run **inside `Pkg.test()`** — but **gated on environment** so they don't slow the PR matrix.

## What's included

**`test/e2e/test_protocol_e2e.jl`** — for both transports, across all three negotiation cases (latest / supported-older / unknown→latest) plus a `tools/list` sanity check:
- **stdio** — pipe JSON-RPC into a spawned `examples/time_server.jl`, assert the negotiated `protocolVersion` in the response.
- **Streamable HTTP** — spawn `examples/simple_http_server.jl`, poll readiness, assert negotiated body version + health version ∈ supported set + working `tools/list`. Skips gracefully if port 3000 is busy.

**`runtests.jl`** — the standard Julia/GitHub gating idiom:
```julia
const ON_CI   = get(ENV, "CI", "false") == "true"          # GitHub Actions sets CI=true
const RUN_E2E = get(ENV, "MCP_TEST_E2E", ON_CI ? "false" : "true") == "true"
```
→ runs **locally by default**, **skipped on the CI matrix** (each spawned server pays full JIT startup), **forceable** either way via `MCP_TEST_E2E`.

**`.github/workflows/e2e.yml`** — a dedicated **nightly** (07:00 UTC) + `workflow_dispatch` job that runs the suite with `MCP_TEST_E2E=true`, so `main`/nightly gets full external-client coverage while PRs stay fast.

## Verification

| Run | Result | e2e |
|-----|--------|-----|
| `Pkg.test()` (local) | **376 passed** | ✅ ran (17 assertions, stdio + HTTP) |
| `CI=true Pkg.test()` | **359 passed** | ⏭️ skipped |

Strictly additive — the existing `julia-actions/julia-runtest` matrix keeps passing (e2e auto-skips there). Asserts the **negotiated response body**, so it's independent of #38/#39 and self-contained on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
