### PR TITLE
fix: Auto-wrap Dict/String tool returns regardless of return_type (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HttpTransport` now defaults `protocol_version` to `LATEST_PROTOCOL_VERSION` (`2025-11-25`)
   and accepts any version in `SUPPORTED_PROTOCOL_VERSIONS` for the `MCP-Protocol-Version` header.
 
+### Fixed
+
+- Tool handlers returning a `Dict`, `String`, or `Tuple{Vector{UInt8},String}` are now
+  auto-wrapped into `Content` regardless of the declared `return_type`, matching the
+  documented contract — previously these converted only when `return_type == TextContent`,
+  so the default `Vector{Content}` raised `ArgumentError`. Fixes #34.
+
 ### Notes
 
 - This is the version-negotiation slice extracted from the larger OAuth 2.1 / 2025-11-25 work

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -71,45 +71,40 @@ function serialize_resource_contents(resource::ResourceContents)
 end
 
 """
-    convert_to_content_type(result::Any, return_type::Type) -> Content
+    convert_to_content_type(result::Any) -> Any
 
-Convert various return types to the appropriate MCP Content type.
+Apply the documented convenience conversions for tool handler return values:
+a `Dict` becomes JSON wrapped in `TextContent`, a `String` becomes `TextContent`,
+and a `Tuple{Vector{UInt8},String}` becomes `ImageContent`.
+
+These conversions are independent of the tool's declared `return_type` (the
+caller validates the converted result against `return_type` afterwards), so the
+documented behavior holds for the default `return_type = Vector{Content}` too.
 
 # Arguments
-- `result::Any`: The result value to convert
-- `return_type::Type`: The target Content type to convert to
+- `result::Any`: The raw value returned by a tool handler
 
 # Returns
-- `Content`: The converted Content object or the original result if no conversion is applicable
+- `Any`: A `Content` object for the convenience cases above; otherwise `result` unchanged
 """
-function convert_to_content_type(result::Any, return_type::Type)
-    # Dict to TextContent conversion
-    if result isa Dict && return_type == TextContent
-        return TextContent(
-            type = "text",
-            text = JSON3.write(result)
-        )
+function convert_to_content_type(result::Any)
+    # Dict -> JSON string wrapped in TextContent
+    if result isa AbstractDict
+        return TextContent(type = "text", text = JSON3.write(result))
     end
-    
-    # String to TextContent conversion
-    if result isa String && return_type == TextContent
-        return TextContent(
-            type = "text",
-            text = result
-        )
+
+    # String -> TextContent
+    if result isa AbstractString
+        return TextContent(type = "text", text = String(result))
     end
-    
-    # For ImageContent, if we have the raw data as Vector{UInt8} and a mime_type string
-    if result isa Tuple{Vector{UInt8}, String} && return_type == ImageContent
+
+    # (raw bytes, mime type) -> ImageContent
+    if result isa Tuple{Vector{UInt8}, String}
         data, mime_type = result
-        return ImageContent(
-            type = "image",
-            data = data,
-            mime_type = mime_type
-        )
+        return ImageContent(type = "image", data = data, mime_type = mime_type)
     end
-    
-    # If no conversion is needed or applicable, return as is
+
+    # Not a convenience type; leave as-is for the caller to validate against return_type
     return result
 end
 
@@ -562,8 +557,8 @@ function handle_call_tool(ctx::RequestContext, params::CallToolParams)::HandlerR
             )
         end
         
-        # Apply automatic conversion to the expected return type
-        result = convert_to_content_type(result, tool.return_type)
+        # Apply the documented convenience conversions (Dict/String/bytes -> Content)
+        result = convert_to_content_type(result)
 
         # Check if result is a vector of content or single content
         is_vector = result isa Vector && all(x -> x isa Content, result)

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -573,7 +573,13 @@ function handle_call_tool(ctx::RequestContext, params::CallToolParams)::HandlerR
         elseif result isa Content
             # Single content - check if it matches declared type or if Vector was expected
             if tool.return_type <: Vector
-                # If Vector was expected but single content returned, wrap it
+                # A Vector was expected but a single Content was returned: wrap it,
+                # but only if it satisfies the vector's declared element type (so a
+                # convenience-converted value can't silently violate e.g. Vector{ImageContent}).
+                elt = eltype(tool.return_type)
+                if !(result isa elt)
+                    throw(ArgumentError("Tool returned $(typeof(result)), expected element of $(tool.return_type)"))
+                end
                 result = [result]
                 is_vector = true
             elseif !(result isa tool.return_type)

--- a/test/features/tools.jl
+++ b/test/features/tools.jl
@@ -523,3 +523,48 @@ end
         @test !("count" in schema["required"])
     end
 end
+
+@testset "Convenience return conversions (issue #34)" begin
+    # A tool returning a raw Dict or String with the DEFAULT return_type
+    # (Vector{Content}) must auto-wrap per the documented contract, not error.
+    server = mcp_server(name = "convert-test", description = "")
+    register!(server, MCPTool(
+        name = "dict_tool",
+        description = "returns a Dict",
+        handler = (args) -> Dict("answer" => 42, "ok" => true),
+        parameters = ToolParameter[],
+    ))
+    register!(server, MCPTool(
+        name = "string_tool",
+        description = "returns a String",
+        handler = (args) -> "plain text result",
+        parameters = ToolParameter[],
+    ))
+
+    @testset "Dict return wraps in JSON TextContent" begin
+        ctx = RequestContext(server = server, request_id = 1)
+        result = handle_call_tool(ctx, CallToolParams(name = "dict_tool", arguments = nothing))
+
+        @test isnothing(result.error)
+        @test result.response.result isa CallToolResult
+        @test result.response.result.is_error == false
+        @test length(result.response.result.content) == 1
+        @test result.response.result.content[1]["type"] == "text"
+        # The text is the JSON encoding of the returned Dict
+        parsed = JSON3.read(result.response.result.content[1]["text"])
+        @test parsed.answer == 42
+        @test parsed.ok == true
+    end
+
+    @testset "String return wraps in TextContent" begin
+        ctx = RequestContext(server = server, request_id = 2)
+        result = handle_call_tool(ctx, CallToolParams(name = "string_tool", arguments = nothing))
+
+        @test isnothing(result.error)
+        @test result.response.result isa CallToolResult
+        @test result.response.result.is_error == false
+        @test length(result.response.result.content) == 1
+        @test result.response.result.content[1]["type"] == "text"
+        @test result.response.result.content[1]["text"] == "plain text result"
+    end
+end

--- a/test/features/tools.jl
+++ b/test/features/tools.jl
@@ -567,4 +567,37 @@ end
         @test result.response.result.content[1]["type"] == "text"
         @test result.response.result.content[1]["text"] == "plain text result"
     end
+
+    @testset "Image tuple return wraps in ImageContent" begin
+        register!(server, MCPTool(
+            name = "image_tool",
+            description = "returns raw image bytes + mime",
+            handler = (args) -> (UInt8[0x89, 0x50, 0x4e, 0x47], "image/png"),
+            parameters = ToolParameter[],
+        ))
+        ctx = RequestContext(server = server, request_id = 3)
+        result = handle_call_tool(ctx, CallToolParams(name = "image_tool", arguments = nothing))
+
+        @test isnothing(result.error)
+        @test result.response.result.is_error == false
+        @test length(result.response.result.content) == 1
+        @test result.response.result.content[1]["type"] == "image"
+        @test haskey(result.response.result.content[1], "data")
+    end
+
+    @testset "Converted content is still validated against a typed return_type" begin
+        # Declaring Vector{ImageContent} but returning a Dict (-> TextContent) must
+        # surface an error, not silently produce text.
+        register!(server, MCPTool(
+            name = "typed_mismatch_tool",
+            description = "declares an image vector but returns a Dict",
+            handler = (args) -> Dict("not" => "an image"),
+            parameters = ToolParameter[],
+            return_type = Vector{ImageContent},
+        ))
+        ctx = RequestContext(server = server, request_id = 4)
+        result = handle_call_tool(ctx, CallToolParams(name = "typed_mismatch_tool", arguments = nothing))
+
+        @test !isnothing(result.error)
+    end
 end


### PR DESCRIPTION
## Summary

Fixes #34. A tool handler that returns a raw `Dict` (or `String`) — as the docs explicitly say is supported — raised:

```
MCP error -32603: Tool execution failed: ArgumentError("Tool must return Content or Vector{<:Content}, got Dict{String, Any}")
```

## Root cause

`convert_to_content_type` gated every convenience conversion on the *declared* return type:

```julia
if result isa Dict && return_type == TextContent      # ...
if result isa String && return_type == TextContent    # ...
if result isa Tuple{Vector{UInt8},String} && return_type == ImageContent  # ...
```

But the **default** `return_type` is `Vector{Content}`, so none of these ever fire by default — the `Dict`/`String` fell through to the generic `throw`. The documented contract (`types.jl`, `docs/src/tools.md`, `api_overview.md`) says all three auto-wrap **unconditionally**.

## Fix

`convert_to_content_type(result)` is now single-arg and the conversions are unconditional:
- `AbstractDict` → JSON `TextContent`
- `AbstractString` → `TextContent`
- `Tuple{Vector{UInt8},String}` → `ImageContent`

The caller still validates the converted result against the tool's `return_type` and wraps single items into a vector for the default `Vector{Content}` — so existing behavior for `Content`/`Vector{Content}`/`CallToolResult` returns is unchanged. (Broadened `Dict`/`String` → `AbstractDict`/`AbstractString` so `LittleDict`, `SubString`, etc. also convert.)

## Verification

Reproduced before/after against a live `process_message` path:

```
# before:  ...error: "Tool must return Content or Vector{<:Content}, got Dict{String, Int64}"
# after:   {"content":[{"text":"{\"answer\":42}","type":"text"}],"is_error":false}
```

Added regression tests (`Dict` and `String` returns via `handle_call_tool`). **Full suite green: 389 passed.** No version bump — part of the unreleased 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
