### PR TITLE
feat: OAuth Resource Server — bearer-token auth for HTTP transport (from #27, PR A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   username allowlist and org-membership check).
 - Protected Resource Metadata discovery (RFC 9728) at `/.well-known/oauth-protected-resource`
   (served publicly); `401`/`403` responses carry an RFC 6750 `WWW-Authenticate` header pointing to it.
-- Helpers exported: `create_simple_auth`, `create_auth_middleware`, `disable_auth`,
-  `create_protected_resource_metadata`, `create_github_resource_metadata`, `authenticate_request`,
-  `extract_bearer_token`, `get_authenticated_user`, `is_auth_enabled`.
-- This is the **Resource Server** slice of the OAuth work (PR #27); the OAuth 2.1 **Authorization
-  Server** (token issuance — DCR, PKCE) remains a separate follow-up.
+- **Per-request auth context**: the authenticated user is threaded per request into
+  `RequestContext.authenticated_user` (no shared transport state, so concurrent requests can't
+  race on identity). Tool handlers may opt into a context-aware form `handler(args, ctx)` (plain
+  `handler(args)` still works) to read it.
+- Helpers exported: `create_simple_auth`, `create_auth_middleware` (requires an explicit
+  validator — no unsafe default), `disable_auth`, `create_protected_resource_metadata`,
+  `create_github_resource_metadata`, `authenticate_request`, `extract_bearer_token`, `is_auth_enabled`.
+- **Security posture** (validators fail closed): `JWTValidator` rejects `alg=none`, requires a
+  valid `exp`, and enforces `iss`/`aud` when configured; `IntrospectionValidator` binds `iss`/`aud`
+  when present; `GitHubOAuthValidator` requires `state == "active"` for org membership; auth error
+  responses are generic (no token/policy oracle).
+- This is the **Resource Server** slice of the OAuth work (PR #27). Deferred follow-ups: JWKS
+  signature verification for `JWTValidator`, SSE session-principal binding + stream expiry,
+  per-tool scope enforcement, case-insensitive allowlists, and the OAuth 2.1 **Authorization
+  Server** (token issuance — DCR, PKCE).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `is_supported_version(version)`
 - All six symbols are exported for use in handlers and downstream code.
 
+#### OAuth Resource Server (MCP 2025-11-25 authorization)
+- Optional bearer-token authentication for the Streamable HTTP transport via new
+  `HttpTransport(; auth, resource_metadata)` keywords. The default is unauthenticated (unchanged).
+- Token validators: `SimpleTokenValidator` (static dev tokens), `JWTValidator` (validates JWT
+  *claims* — **does not verify signatures**; see its docstring warning), `IntrospectionValidator`
+  (RFC 7662), and `GitHubOAuthValidator` (validates GitHub tokens via the API, with optional
+  username allowlist and org-membership check).
+- Protected Resource Metadata discovery (RFC 9728) at `/.well-known/oauth-protected-resource`
+  (served publicly); `401`/`403` responses carry an RFC 6750 `WWW-Authenticate` header pointing to it.
+- Helpers exported: `create_simple_auth`, `create_auth_middleware`, `disable_auth`,
+  `create_protected_resource_metadata`, `create_github_resource_metadata`, `authenticate_request`,
+  `extract_bearer_token`, `get_authenticated_user`, `is_auth_enabled`.
+- This is the **Resource Server** slice of the OAuth work (PR #27); the OAuth 2.1 **Authorization
+  Server** (token issuance — DCR, PKCE) remains a separate follow-up.
+
 ### Changed
 
 - `handle_initialize` now responds with the **negotiated** protocol version instead of a
@@ -38,9 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Notes
 
-- This is the version-negotiation slice extracted from the larger OAuth 2.1 / 2025-11-25 work
-  (PR #27). Threading the negotiated version through `ServerState` for per-request feature
-  gating, and the OAuth authorization server, are deferred to follow-up PRs.
+- 0.5.0 is being assembled incrementally from the larger OAuth 2.1 / 2025-11-25 work (PR #27):
+  protocol negotiation, `ServerState`-based feature gating, and the OAuth Resource Server have
+  landed. The OAuth 2.1 **Authorization Server** (token issuance — DCR, PKCE) remains a follow-up.
 
 ## [0.3.0] - 2025-11-16
 

--- a/src/ModelContextProtocol.jl
+++ b/src/ModelContextProtocol.jl
@@ -130,6 +130,6 @@ export
     create_protected_resource_metadata, create_github_resource_metadata,
     authenticate_request, validate_token, extract_bearer_token,
     GitHubOAuthValidator, create_github_auth, clear_cache!,
-    get_authenticated_user, is_auth_enabled
+    is_auth_enabled
 
 end # module

--- a/src/ModelContextProtocol.jl
+++ b/src/ModelContextProtocol.jl
@@ -57,6 +57,9 @@ include("protocol/messages.jl")
 # 2b. Protocol version negotiation (dependency-free; used by transport + handlers)
 include("protocol/versioning.jl")
 
+# 2c. Authentication — OAuth Resource Server (defines the auth types the HTTP transport references)
+include("auth/auth.jl")
+
 # 3. Transport Layer
 include("transports/base.jl")
 include("transports/stdio.jl")
@@ -117,6 +120,16 @@ export
 
     # Protocol version negotiation and feature gating (MCP 2025-11-25)
     LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS, FEATURE_VERSIONS,
-    negotiate_version, supports, is_supported_version
+    negotiate_version, supports, is_supported_version,
+
+    # Authentication — OAuth Resource Server (MCP 2025-11-25 authorization)
+    AuthProvider, TokenValidator, AuthenticatedUser,
+    OAuthConfig, AuthResult, AuthMiddleware, ProtectedResourceMetadata,
+    SimpleTokenValidator, JWTValidator, IntrospectionValidator,
+    create_auth_middleware, create_simple_auth, disable_auth,
+    create_protected_resource_metadata, create_github_resource_metadata,
+    authenticate_request, validate_token, extract_bearer_token,
+    GitHubOAuthValidator, create_github_auth, clear_cache!,
+    get_authenticated_user, is_auth_enabled
 
 end # module

--- a/src/auth/auth.jl
+++ b/src/auth/auth.jl
@@ -1,0 +1,262 @@
+# src/auth/auth.jl
+# OAuth 2.0 Authorization Framework for MCP
+# Implements MCP 2025-11-25 authorization specification
+
+using Dates: DateTime, now, UTC, Second
+
+"""
+    AuthProvider
+
+Abstract type for authentication providers (GitHub, Google, custom OAuth servers).
+"""
+abstract type AuthProvider end
+
+"""
+    TokenValidator
+
+Abstract type for token validation strategies (JWT, introspection).
+"""
+abstract type TokenValidator end
+
+"""
+    AuthenticatedUser(; subject::String, provider::String,
+                      username::Union{String,Nothing}=nothing,
+                      scopes::Vector{String}=String[],
+                      claims::Dict{String,Any}=Dict{String,Any}())
+
+Represent an authenticated user after successful token validation.
+
+# Fields
+- `subject::String`: Unique user identifier (sub claim from token)
+- `provider::String`: Authentication provider name (e.g., "github", "google")
+- `username::Union{String,Nothing}`: Human-readable username if available
+- `scopes::Vector{String}`: Granted OAuth scopes
+- `claims::Dict{String,Any}`: Raw claims from the token
+"""
+Base.@kwdef struct AuthenticatedUser
+    subject::String
+    provider::String
+    username::Union{String,Nothing} = nothing
+    scopes::Vector{String} = String[]
+    claims::Dict{String,Any} = Dict{String,Any}()
+end
+
+function Base.show(io::IO, user::AuthenticatedUser)
+    name = isnothing(user.username) ? user.subject : user.username
+    print(io, "AuthenticatedUser(", name, "@", user.provider, ")")
+end
+
+"""
+    OAuthConfig(; issuer::String, audience::String,
+                 required_scopes::Vector{String}=String[],
+                 jwks_uri::Union{String,Nothing}=nothing,
+                 introspection_endpoint::Union{String,Nothing}=nothing)
+
+Configure OAuth 2.0 token validation for an MCP server.
+
+# Fields
+- `issuer::String`: Expected token issuer (iss claim)
+- `audience::String`: Expected audience (aud claim) - typically your server's URL
+- `required_scopes::Vector{String}`: Scopes required to access the server
+- `jwks_uri::Union{String,Nothing}`: URL to fetch JSON Web Key Set for JWT validation
+- `introspection_endpoint::Union{String,Nothing}`: Token introspection endpoint URL
+"""
+Base.@kwdef struct OAuthConfig
+    issuer::String
+    audience::String
+    required_scopes::Vector{String} = String[]
+    jwks_uri::Union{String,Nothing} = nothing
+    introspection_endpoint::Union{String,Nothing} = nothing
+end
+
+function Base.show(io::IO, config::OAuthConfig)
+    print(io, "OAuthConfig(issuer=", config.issuer, ", audience=", config.audience, ")")
+end
+
+"""
+    AuthResult
+
+Result of an authentication attempt.
+"""
+struct AuthResult
+    success::Bool
+    user::Union{AuthenticatedUser,Nothing}
+    error::Union{String,Nothing}
+    error_code::Union{Symbol,Nothing}  # :invalid_token, :expired, :insufficient_scope, etc.
+end
+
+# Convenience constructors
+AuthResult(user::AuthenticatedUser) = AuthResult(true, user, nothing, nothing)
+AuthResult(error::String, code::Symbol) = AuthResult(false, nothing, error, code)
+
+function Base.show(io::IO, result::AuthResult)
+    if result.success
+        print(io, "AuthResult(success, ", result.user, ")")
+    else
+        print(io, "AuthResult(failed, :", result.error_code, ")")
+    end
+end
+
+"""
+    AuthMiddleware(; config::OAuthConfig,
+                    validator::TokenValidator,
+                    allowlist::Union{Set{String},Nothing}=nothing,
+                    enabled::Bool=true)
+
+Middleware for authenticating HTTP requests to an MCP server.
+
+# Fields
+- `config::OAuthConfig`: OAuth configuration
+- `validator::TokenValidator`: Token validation strategy
+- `allowlist::Union{Set{String},Nothing}`: Optional set of allowed usernames/subjects
+- `enabled::Bool`: Whether authentication is enabled (for development/testing)
+"""
+Base.@kwdef mutable struct AuthMiddleware
+    config::OAuthConfig
+    validator::TokenValidator
+    allowlist::Union{Set{String},Nothing} = nothing
+    enabled::Bool = true
+end
+
+function Base.show(io::IO, auth::AuthMiddleware)
+    status = auth.enabled ? "enabled" : "disabled"
+    allowlist_info = isnothing(auth.allowlist) ? "" : ", $(length(auth.allowlist)) allowed"
+    print(io, "AuthMiddleware(", status, allowlist_info, ")")
+end
+
+"""
+    ProtectedResourceMetadata(; resource::String,
+                               authorization_servers::Vector{String},
+                               scopes_supported::Vector{String}=String[],
+                               bearer_methods_supported::Vector{String}=["header"])
+
+MCP Protected Resource Metadata per RFC 9728.
+Served at `.well-known/oauth-protected-resource`.
+
+# Fields
+- `resource::String`: The protected resource identifier (your server URL)
+- `authorization_servers::Vector{String}`: URLs of authorization servers that can issue tokens
+- `scopes_supported::Vector{String}`: OAuth scopes the resource understands
+- `bearer_methods_supported::Vector{String}`: How tokens can be sent (header, body, query)
+"""
+Base.@kwdef struct ProtectedResourceMetadata
+    resource::String
+    authorization_servers::Vector{String}
+    scopes_supported::Vector{String} = String[]
+    bearer_methods_supported::Vector{String} = ["header"]
+end
+
+function Base.show(io::IO, meta::ProtectedResourceMetadata)
+    print(io, "ProtectedResourceMetadata(", meta.resource, ")")
+end
+
+"""
+    extract_bearer_token(authorization_header::String) -> Union{String,Nothing}
+
+Extract Bearer token from Authorization header.
+
+# Arguments
+- `authorization_header::String`: The Authorization header value
+
+# Returns
+The token if present and valid format, `nothing` otherwise.
+"""
+function extract_bearer_token(authorization_header::String)
+    if startswith(authorization_header, "Bearer ")
+        return strip(authorization_header[8:end])
+    end
+    return nothing
+end
+
+"""
+    validate_token(validator::TokenValidator, token::AbstractString, config::OAuthConfig) -> AuthResult
+
+Validate an OAuth token using the specified validator.
+
+# Arguments
+- `validator::TokenValidator`: The validation strategy to use
+- `token::AbstractString`: The token to validate
+- `config::OAuthConfig`: OAuth configuration with expected issuer, audience, etc.
+
+# Returns
+- `AuthResult`: Success with user info, or failure with error details
+"""
+function validate_token end  # To be implemented by concrete validators
+
+"""
+    check_allowlist(user::AuthenticatedUser, allowlist::Set{String}) -> Bool
+
+Check if user is in the allowlist.
+
+# Arguments
+- `user::AuthenticatedUser`: The authenticated user
+- `allowlist::Set{String}`: Set of allowed usernames or subjects
+
+# Returns
+`true` if user is allowed.
+"""
+function check_allowlist(user::AuthenticatedUser, allowlist::Set{String})
+    # Check both username and subject
+    if !isnothing(user.username) && user.username in allowlist
+        return true
+    end
+    return user.subject in allowlist
+end
+
+"""
+    authenticate_request(middleware::AuthMiddleware, authorization_header::Union{String,Nothing}) -> AuthResult
+
+Authenticate an HTTP request using the auth middleware.
+
+# Arguments
+- `middleware::AuthMiddleware`: The authentication middleware
+- `authorization_header::Union{String,Nothing}`: The Authorization header value
+
+# Returns
+`AuthResult` indicating success with user info, or failure with error details.
+"""
+function authenticate_request(
+    middleware::AuthMiddleware,
+    authorization_header::Union{String,Nothing}
+)
+    # Skip if auth disabled
+    if !middleware.enabled
+        return AuthResult(AuthenticatedUser(
+            subject = "anonymous",
+            provider = "none",
+            username = "anonymous"
+        ))
+    end
+
+    # Check for Authorization header
+    if isnothing(authorization_header) || isempty(authorization_header)
+        return AuthResult("Missing Authorization header", :missing_token)
+    end
+
+    # Extract Bearer token
+    token = extract_bearer_token(authorization_header)
+    if isnothing(token)
+        return AuthResult("Invalid Authorization header format. Expected: Bearer <token>", :invalid_format)
+    end
+
+    # Validate the token
+    result = validate_token(middleware.validator, token, middleware.config)
+    if !result.success
+        return result
+    end
+
+    # Check allowlist if configured
+    if !isnothing(middleware.allowlist)
+        if !check_allowlist(result.user, middleware.allowlist)
+            return AuthResult("User not in allowlist", :forbidden)
+        end
+    end
+
+    return result
+end
+
+# Include sub-modules
+include("token.jl")
+include("middleware.jl")
+include("metadata.jl")
+include("providers/github.jl")

--- a/src/auth/metadata.jl
+++ b/src/auth/metadata.jl
@@ -1,0 +1,110 @@
+# src/auth/metadata.jl
+# Protected Resource Metadata per RFC 9728 and MCP 2025-11-25 spec
+
+"""
+    WELL_KNOWN_PATH
+
+Standard path for Protected Resource Metadata.
+"""
+const WELL_KNOWN_PATH::String = "/.well-known/oauth-protected-resource"
+
+"""
+    GitHubAuthorizationServer
+
+Pre-configured authorization server URL for GitHub OAuth.
+"""
+const GitHubAuthorizationServer::String = "https://github.com/login/oauth"
+
+"""
+    create_protected_resource_metadata(resource_url::String,
+                                       authorization_servers::Vector{String};
+                                       scopes::Vector{String}=String[]) -> ProtectedResourceMetadata
+
+Create Protected Resource Metadata for the MCP server.
+
+# Arguments
+- `resource_url::String`: The URL of your MCP server (the protected resource)
+- `authorization_servers::Vector{String}`: URLs of OAuth authorization servers
+- `scopes::Vector{String}`: OAuth scopes the server understands
+
+# Example
+```julia
+metadata = create_protected_resource_metadata(
+    "https://mcp.example.com",
+    ["https://github.com/login/oauth"],
+    scopes = ["read:user", "repo"]
+)
+```
+"""
+function create_protected_resource_metadata(
+    resource_url::String,
+    authorization_servers::Vector{String};
+    scopes::Vector{String} = String[]
+)
+    return ProtectedResourceMetadata(
+        resource = resource_url,
+        authorization_servers = authorization_servers,
+        scopes_supported = scopes,
+        bearer_methods_supported = ["header"]
+    )
+end
+
+"""
+    metadata_to_json(metadata::ProtectedResourceMetadata) -> String
+
+Serialize Protected Resource Metadata to JSON for HTTP response.
+"""
+function metadata_to_json(metadata::ProtectedResourceMetadata)
+    return JSON3.write(Dict{String,Any}(
+        "resource" => metadata.resource,
+        "authorization_servers" => metadata.authorization_servers,
+        "scopes_supported" => metadata.scopes_supported,
+        "bearer_methods_supported" => metadata.bearer_methods_supported
+    ))
+end
+
+"""
+    handle_well_known_request(metadata::ProtectedResourceMetadata) -> Tuple{Int,String,Dict{String,String}}
+
+Handle a request to the .well-known/oauth-protected-resource endpoint.
+
+# Returns
+Tuple of (status_code, body, headers).
+"""
+function handle_well_known_request(metadata::ProtectedResourceMetadata)
+    body = metadata_to_json(metadata)
+    headers = Dict{String,String}(
+        "Content-Type" => "application/json",
+        "Cache-Control" => "max-age=3600"  # Cache for 1 hour
+    )
+    return (200, body, headers)
+end
+
+"""
+    create_github_resource_metadata(resource_url::String;
+                                   scopes::Vector{String}=["read:user"]) -> ProtectedResourceMetadata
+
+Create Protected Resource Metadata configured for GitHub OAuth.
+
+# Arguments
+- `resource_url::String`: Your MCP server URL
+- `scopes::Vector{String}`: GitHub OAuth scopes to request (default: ["read:user"])
+
+# Example
+```julia
+metadata = create_github_resource_metadata(
+    "https://mcp.lidkelab.org",
+    scopes = ["read:user", "read:org"]
+)
+```
+"""
+function create_github_resource_metadata(
+    resource_url::String;
+    scopes::Vector{String} = ["read:user"]
+)
+    return create_protected_resource_metadata(
+        resource_url,
+        [GitHubAuthorizationServer],
+        scopes = scopes
+    )
+end

--- a/src/auth/middleware.jl
+++ b/src/auth/middleware.jl
@@ -1,0 +1,178 @@
+# src/auth/middleware.jl
+# HTTP authentication middleware integration
+
+"""
+    AuthError
+
+Error codes for authentication failures per MCP spec.
+"""
+module AuthErrors
+    const MISSING_TOKEN = 401
+    const INVALID_TOKEN = 401
+    const EXPIRED_TOKEN = 401
+    const INSUFFICIENT_SCOPE = 403
+    const FORBIDDEN = 403
+end
+
+"""
+    auth_error_response(error_code::Symbol, message::String) -> Tuple{Int,String,Dict{String,String}}
+
+Generate HTTP response for authentication errors.
+
+# Returns
+- Tuple of (status_code, body, headers)
+"""
+function auth_error_response(error_code::Symbol, message::String; resource_metadata_url::Union{String,Nothing}=nothing)
+    status = if error_code in (:missing_token, :invalid_token, :invalid_format, :expired, :not_yet_valid, :invalid_issuer, :invalid_audience)
+        401
+    elseif error_code in (:insufficient_scope, :forbidden)
+        403
+    else
+        401
+    end
+
+    # WWW-Authenticate header per RFC 6750 and RFC 9728
+    # Include resource_metadata URL to help clients discover auth requirements
+    www_auth = if error_code == :missing_token
+        if !isnothing(resource_metadata_url)
+            "Bearer resource_metadata=\"$resource_metadata_url\""
+        else
+            "Bearer"
+        end
+    elseif error_code == :insufficient_scope
+        base = "Bearer error=\"insufficient_scope\", error_description=\"$message\""
+        if !isnothing(resource_metadata_url)
+            "$base, resource_metadata=\"$resource_metadata_url\""
+        else
+            base
+        end
+    else
+        base = "Bearer error=\"invalid_token\", error_description=\"$message\""
+        if !isnothing(resource_metadata_url)
+            "$base, resource_metadata=\"$resource_metadata_url\""
+        else
+            base
+        end
+    end
+
+    headers = Dict{String,String}(
+        "WWW-Authenticate" => www_auth,
+        "Content-Type" => "application/json"
+    )
+
+    body = JSON3.write(Dict(
+        "error" => String(error_code),
+        "error_description" => message
+    ))
+
+    return (status, body, headers)
+end
+
+"""
+    RequestAuthContext
+
+Authentication context attached to authenticated requests.
+"""
+Base.@kwdef struct RequestAuthContext
+    user::AuthenticatedUser
+    token::String
+    authenticated_at::DateTime = now(UTC)
+end
+
+"""
+    create_auth_middleware(config::OAuthConfig;
+                          validator::TokenValidator=JWTValidator(),
+                          allowlist::Union{Set{String},Nothing}=nothing,
+                          enabled::Bool=true) -> AuthMiddleware
+
+Create an authentication middleware for HTTP transport.
+
+# Arguments
+- `config::OAuthConfig`: OAuth configuration
+- `validator::TokenValidator`: Token validation strategy (default: JWTValidator)
+- `allowlist::Union{Set{String},Nothing}`: Optional allowlist of usernames/subjects
+- `enabled::Bool`: Whether auth is enabled (default: true)
+
+# Example
+```julia
+auth = create_auth_middleware(
+    OAuthConfig(
+        issuer = "https://github.com",
+        audience = "my-mcp-server"
+    ),
+    allowlist = Set(["user1", "user2"])
+)
+```
+"""
+function create_auth_middleware(
+    config::OAuthConfig;
+    validator::TokenValidator = JWTValidator(),
+    allowlist::Union{Set{String},Nothing} = nothing,
+    enabled::Bool = true
+)
+    return AuthMiddleware(
+        config = config,
+        validator = validator,
+        allowlist = allowlist,
+        enabled = enabled
+    )
+end
+
+"""
+    create_simple_auth(tokens::Dict{String,String};
+                      allowlist::Union{Set{String},Nothing}=nothing) -> AuthMiddleware
+
+Create a simple API key-based authentication middleware.
+
+# Arguments
+- `tokens::Dict{String,String}`: Map of API keys to usernames
+- `allowlist::Union{Set{String},Nothing}`: Optional additional allowlist
+
+# Example
+```julia
+auth = create_simple_auth(Dict(
+    "sk-abc123" => "user1",
+    "sk-def456" => "user2"
+))
+```
+"""
+function create_simple_auth(
+    tokens::Dict{String,String};
+    allowlist::Union{Set{String},Nothing} = nothing
+)
+    validator = SimpleTokenValidator()
+
+    for (token, username) in tokens
+        add_token!(validator, token, AuthenticatedUser(
+            subject = username,
+            provider = "api_key",
+            username = username
+        ))
+    end
+
+    config = OAuthConfig(
+        issuer = "local",
+        audience = "local"
+    )
+
+    return AuthMiddleware(
+        config = config,
+        validator = validator,
+        allowlist = allowlist,
+        enabled = true
+    )
+end
+
+"""
+    disable_auth() -> AuthMiddleware
+
+Create a disabled auth middleware (for development/testing).
+All requests will be allowed with an anonymous user.
+"""
+function disable_auth()
+    return AuthMiddleware(
+        config = OAuthConfig(issuer = "none", audience = "none"),
+        validator = SimpleTokenValidator(),
+        enabled = false
+    )
+end

--- a/src/auth/middleware.jl
+++ b/src/auth/middleware.jl
@@ -105,6 +105,7 @@ auth = create_auth_middleware(
         issuer = "https://github.com",
         audience = "my-mcp-server"
     ),
+    validator = IntrospectionValidator(client_id = "id", client_secret = "secret"),
     allowlist = Set(["user1", "user2"])
 )
 ```

--- a/src/auth/middleware.jl
+++ b/src/auth/middleware.jl
@@ -23,48 +23,50 @@ Generate HTTP response for authentication errors.
 - Tuple of (status_code, body, headers)
 """
 function auth_error_response(error_code::Symbol, message::String; resource_metadata_url::Union{String,Nothing}=nothing)
-    status = if error_code in (:missing_token, :invalid_token, :invalid_format, :expired, :not_yet_valid, :invalid_issuer, :invalid_audience)
-        401
-    elseif error_code in (:insufficient_scope, :forbidden)
-        403
+    # Map internal validator codes to an HTTP status and a GENERIC, client-facing
+    # OAuth error. We deliberately do NOT echo the specific reason (expired vs.
+    # wrong issuer vs. malformed vs. which scope) — that would be a token/policy
+    # oracle. `message` is retained for the caller / server-side logging only.
+    is_scope = error_code === :insufficient_scope
+    is_forbidden = is_scope || error_code === :forbidden
+    status = is_forbidden ? 403 : 401
+
+    oauth_error = if is_forbidden
+        "insufficient_scope"
+    elseif error_code === :missing_token
+        "invalid_request"
     else
-        401
+        "invalid_token"
+    end
+    description = if is_forbidden
+        "The request requires higher privileges than the access token provides."
+    elseif error_code === :missing_token
+        "Authentication required."
+    else
+        "The access token is missing, invalid, or expired."
     end
 
-    # WWW-Authenticate header per RFC 6750 and RFC 9728
-    # Include resource_metadata URL to help clients discover auth requirements
-    www_auth = if error_code == :missing_token
-        if !isnothing(resource_metadata_url)
-            "Bearer resource_metadata=\"$resource_metadata_url\""
-        else
-            "Bearer"
-        end
-    elseif error_code == :insufficient_scope
-        base = "Bearer error=\"insufficient_scope\", error_description=\"$message\""
-        if !isnothing(resource_metadata_url)
-            "$base, resource_metadata=\"$resource_metadata_url\""
-        else
-            base
-        end
-    else
-        base = "Bearer error=\"invalid_token\", error_description=\"$message\""
-        if !isnothing(resource_metadata_url)
-            "$base, resource_metadata=\"$resource_metadata_url\""
-        else
-            base
-        end
+    # WWW-Authenticate per RFC 6750 / 9728. Every value comes from a fixed
+    # vocabulary or server-controlled config (resource_metadata_url), so there is
+    # no untrusted interpolation to escape.
+    params = String[]
+    if error_code !== :missing_token
+        push!(params, "error=\"$(oauth_error)\"")
+        push!(params, "error_description=\"$(description)\"")
     end
+    if !isnothing(resource_metadata_url)
+        push!(params, "resource_metadata=\"$(resource_metadata_url)\"")
+    end
+    www_auth = isempty(params) ? "Bearer" : "Bearer " * join(params, ", ")
 
     headers = Dict{String,String}(
         "WWW-Authenticate" => www_auth,
         "Content-Type" => "application/json"
     )
-
     body = JSON3.write(Dict(
-        "error" => String(error_code),
-        "error_description" => message
+        "error" => oauth_error,
+        "error_description" => description
     ))
-
     return (status, body, headers)
 end
 
@@ -81,15 +83,18 @@ end
 
 """
     create_auth_middleware(config::OAuthConfig;
-                          validator::TokenValidator=JWTValidator(),
+                          validator::TokenValidator,
                           allowlist::Union{Set{String},Nothing}=nothing,
                           enabled::Bool=true) -> AuthMiddleware
 
-Create an authentication middleware for HTTP transport.
+Create an authentication middleware for the HTTP transport.
 
 # Arguments
 - `config::OAuthConfig`: OAuth configuration
-- `validator::TokenValidator`: Token validation strategy (default: JWTValidator)
+- `validator::TokenValidator`: Token validation strategy (REQUIRED — no default, so
+  an unsafe validator is never selected implicitly. Note `JWTValidator` does not verify
+  signatures; prefer `IntrospectionValidator` or `GitHubOAuthValidator` for tokens from
+  external issuers.)
 - `allowlist::Union{Set{String},Nothing}`: Optional allowlist of usernames/subjects
 - `enabled::Bool`: Whether auth is enabled (default: true)
 
@@ -106,7 +111,7 @@ auth = create_auth_middleware(
 """
 function create_auth_middleware(
     config::OAuthConfig;
-    validator::TokenValidator = JWTValidator(),
+    validator::TokenValidator,
     allowlist::Union{Set{String},Nothing} = nothing,
     enabled::Bool = true
 )

--- a/src/auth/providers/github.jl
+++ b/src/auth/providers/github.jl
@@ -1,0 +1,293 @@
+# src/auth/providers/github.jl
+# GitHub OAuth provider for MCP authentication
+
+using Dates: DateTime, now, UTC, Second
+
+"""
+    GITHUB_API_URL
+
+Base URL for GitHub API.
+"""
+const GITHUB_API_URL::String = "https://api.github.com"
+
+"""
+    GitHubOAuthValidator(; cache_ttl_seconds::Int=300)
+
+Token validator for GitHub OAuth access tokens.
+Validates tokens by calling GitHub's /user API endpoint.
+
+# Fields
+- `cache_ttl_seconds::Int`: How long to cache user info (default: 5 minutes)
+- `user_cache::Dict{String,Tuple{AuthenticatedUser,DateTime}}`: Cache of validated tokens
+- `cache_lock::ReentrantLock`: Lock for thread-safe cache access
+"""
+struct GitHubOAuthValidator <: TokenValidator
+    cache_ttl_seconds::Int
+    user_cache::Dict{String,Tuple{AuthenticatedUser,DateTime}}
+    cache_lock::ReentrantLock
+end
+
+function GitHubOAuthValidator(; cache_ttl_seconds::Int=300)
+    GitHubOAuthValidator(
+        cache_ttl_seconds,
+        Dict{String,Tuple{AuthenticatedUser,DateTime}}(),
+        ReentrantLock()
+    )
+end
+
+function Base.show(io::IO, v::GitHubOAuthValidator)
+    cached = lock(v.cache_lock) do
+        length(v.user_cache)
+    end
+    print(io, "GitHubOAuthValidator(ttl=", v.cache_ttl_seconds, "s, cached=", cached, ")")
+end
+
+"""
+    fetch_github_user(token::String) -> Union{Dict{String,Any},Nothing}
+
+Fetch user information from GitHub API using an access token.
+Returns `nothing` if the token is invalid or the request fails.
+"""
+function fetch_github_user(token::String)
+    try
+        response = HTTP.get(
+            "$GITHUB_API_URL/user",
+            [
+                "Authorization" => "Bearer $token",
+                "Accept" => "application/vnd.github+json",
+                "X-GitHub-Api-Version" => "2022-11-28"
+            ]
+        )
+
+        if response.status == 200
+            return JSON3.read(String(response.body), Dict{String,Any})
+        end
+        return nothing
+    catch e
+        if e isa HTTP.StatusError
+            # 401 = invalid token, other status codes are also failures
+            return nothing
+        elseif e isa HTTP.RequestError
+            @warn "GitHub API request failed" exception=(e, catch_backtrace())
+            return nothing
+        else
+            rethrow(e)
+        end
+    end
+end
+
+"""
+    check_github_org_membership(token::String, org::String) -> Bool
+
+Check if the authenticated user is a member of the specified GitHub organization.
+"""
+function check_github_org_membership(token::String, org::String)
+    try
+        response = HTTP.get(
+            "$GITHUB_API_URL/user/memberships/orgs/$org",
+            [
+                "Authorization" => "Bearer $token",
+                "Accept" => "application/vnd.github+json",
+                "X-GitHub-Api-Version" => "2022-11-28"
+            ]
+        )
+        return response.status == 200
+    catch e
+        if e isa HTTP.StatusError
+            # 404 = not a member, 403 = org not found or no permission
+            return false
+        elseif e isa HTTP.RequestError
+            @warn "GitHub org membership check failed" exception=(e, catch_backtrace())
+            return false
+        else
+            rethrow(e)
+        end
+    end
+end
+
+"""
+    validate_token(validator::GitHubOAuthValidator, token::AbstractString, config::OAuthConfig) -> AuthResult
+
+Validate a GitHub OAuth access token by calling GitHub's API.
+"""
+function validate_token(validator::GitHubOAuthValidator, token::AbstractString, config::OAuthConfig)
+    token_str = String(token)
+
+    # Check cache first (thread-safe)
+    cached_result = lock(validator.cache_lock) do
+        if haskey(validator.user_cache, token_str)
+            user, cached_at = validator.user_cache[token_str]
+            if now(UTC) - cached_at < Second(validator.cache_ttl_seconds)
+                return AuthResult(user)
+            else
+                delete!(validator.user_cache, token_str)
+            end
+        end
+        return nothing
+    end
+
+    if !isnothing(cached_result)
+        return cached_result
+    end
+
+    # Fetch user from GitHub
+    user_data = fetch_github_user(token_str)
+
+    if isnothing(user_data)
+        return AuthResult("Invalid GitHub token", :invalid_token)
+    end
+
+    # Extract username
+    username = get(user_data, "login", nothing)
+    if isnothing(username)
+        return AuthResult("GitHub user has no login", :invalid_token)
+    end
+
+    # Build authenticated user
+    user = AuthenticatedUser(
+        subject = string(get(user_data, "id", username)),
+        provider = "github",
+        username = username,
+        scopes = String[],  # GitHub doesn't expose scopes in /user response
+        claims = Dict{String,Any}(
+            "login" => username,
+            "id" => get(user_data, "id", nothing),
+            "name" => get(user_data, "name", nothing),
+            "email" => get(user_data, "email", nothing),
+            "avatar_url" => get(user_data, "avatar_url", nothing),
+            "html_url" => get(user_data, "html_url", nothing)
+        )
+    )
+
+    # Cache the result (thread-safe)
+    lock(validator.cache_lock) do
+        validator.user_cache[token_str] = (user, now(UTC))
+    end
+
+    return AuthResult(user)
+end
+
+"""
+    create_github_auth(; allowed_users::Union{Vector{String},Set{String}}=String[],
+                        required_org::Union{String,Nothing}=nothing,
+                        cache_ttl_seconds::Int=300) -> AuthMiddleware
+
+Create an authentication middleware configured for GitHub OAuth.
+
+# Arguments
+- `allowed_users`: List of GitHub usernames allowed to access the server
+- `required_org`: Optionally require membership in a GitHub organization
+- `cache_ttl_seconds`: How long to cache validated tokens (default: 5 minutes)
+
+# Returns
+`AuthMiddleware` configured for GitHub OAuth validation.
+
+# Example
+```julia
+# Allow specific users
+auth = create_github_auth(
+    allowed_users = ["user1", "user2", "user3"]
+)
+
+# Require organization membership
+auth = create_github_auth(
+    required_org = "JuliaSMLM"
+)
+
+# Both user allowlist and org requirement
+auth = create_github_auth(
+    allowed_users = ["user1", "user2"],
+    required_org = "LidkeLab"
+)
+```
+"""
+function create_github_auth(;
+    allowed_users::Union{Vector{String},Set{String}} = String[],
+    required_org::Union{String,Nothing} = nothing,
+    cache_ttl_seconds::Int = 300
+)
+    # Convert to Set if needed
+    allowlist = if allowed_users isa Set
+        allowed_users
+    elseif isempty(allowed_users)
+        nothing  # No allowlist = allow all authenticated users
+    else
+        Set(allowed_users)
+    end
+
+    validator = GitHubOAuthValidatorWithOrg(
+        base_validator = GitHubOAuthValidator(cache_ttl_seconds = cache_ttl_seconds),
+        required_org = required_org
+    )
+
+    config = OAuthConfig(
+        issuer = "https://github.com",
+        audience = "github"
+    )
+
+    return AuthMiddleware(
+        config = config,
+        validator = validator,
+        allowlist = allowlist,
+        enabled = true
+    )
+end
+
+"""
+    GitHubOAuthValidatorWithOrg <: TokenValidator
+
+Wrapper validator that adds organization membership checking.
+
+# Fields
+- `base_validator::GitHubOAuthValidator`: The underlying GitHub token validator
+- `required_org::Union{String,Nothing}`: Required organization membership
+"""
+struct GitHubOAuthValidatorWithOrg <: TokenValidator
+    base_validator::GitHubOAuthValidator
+    required_org::Union{String,Nothing}
+end
+
+function GitHubOAuthValidatorWithOrg(; base_validator::GitHubOAuthValidator, required_org=nothing)
+    GitHubOAuthValidatorWithOrg(base_validator, required_org)
+end
+
+function Base.show(io::IO, v::GitHubOAuthValidatorWithOrg)
+    org_info = isnothing(v.required_org) ? "" : ", org=$(v.required_org)"
+    print(io, "GitHubOAuthValidatorWithOrg(", v.base_validator, org_info, ")")
+end
+
+function validate_token(validator::GitHubOAuthValidatorWithOrg, token::AbstractString, config::OAuthConfig)
+    # First validate the token with base validator
+    result = validate_token(validator.base_validator, token, config)
+
+    if !result.success
+        return result
+    end
+
+    # Check org membership if required
+    if !isnothing(validator.required_org)
+        if !check_github_org_membership(String(token), validator.required_org)
+            return AuthResult(
+                "User is not a member of required organization: $(validator.required_org)",
+                :forbidden
+            )
+        end
+    end
+
+    return result
+end
+
+"""
+    clear_cache!(validator::GitHubOAuthValidator)
+
+Clear the token validation cache.
+"""
+function clear_cache!(validator::GitHubOAuthValidator)
+    lock(validator.cache_lock) do
+        empty!(validator.user_cache)
+    end
+end
+
+function clear_cache!(validator::GitHubOAuthValidatorWithOrg)
+    clear_cache!(validator.base_validator)
+end

--- a/src/auth/providers/github.jl
+++ b/src/auth/providers/github.jl
@@ -91,7 +91,14 @@ function check_github_org_membership(token::String, org::String)
                 "X-GitHub-Api-Version" => "2022-11-28"
             ]
         )
-        return response.status == 200
+        response.status == 200 || return false
+        # A 200 can still be a *pending* invitation; only "active" membership grants access.
+        membership = try
+            JSON3.read(String(response.body), Dict{String,Any})
+        catch
+            return false
+        end
+        return get(membership, "state", "") == "active"
     catch e
         if e isa HTTP.StatusError
             # 404 = not a member, 403 = org not found or no permission

--- a/src/auth/token.jl
+++ b/src/auth/token.jl
@@ -212,11 +212,12 @@ function validate_token(validator::JWTValidator, token::AbstractString, config::
     # Reject "alg: none" (unsigned) tokens outright. Even though we don't verify
     # signatures yet, accepting alg=none is a classic JWT authentication bypass.
     header = decode_jwt_header(tok)
-    if !isnothing(header)
-        alg = String(get(header, "alg", ""))
-        if isempty(alg) || lowercase(alg) == "none"
-            return AuthResult("Unsupported or missing JWT algorithm", :invalid_token)
-        end
+    if isnothing(header)
+        return AuthResult("Invalid JWT format", :invalid_format)
+    end
+    alg = get(header, "alg", nothing)
+    if !(alg isa AbstractString) || isempty(alg) || lowercase(String(alg)) == "none"
+        return AuthResult("Unsupported or missing JWT algorithm", :invalid_token)
     end
 
     claims = decode_jwt_payload(tok)
@@ -288,19 +289,20 @@ function validate_token(validator::IntrospectionValidator, token::AbstractString
         # Audience / issuer binding: a token that is active at the AS but was minted
         # for a different resource must not be accepted here. Enforce when the
         # introspection response carries the claim (RFC 7662 responses vary).
+        # When an issuer/audience is configured the introspection response MUST carry a
+        # matching claim — fail closed if absent, so a token minted for another resource
+        # (active at a shared AS) cannot be replayed here.
         if !isempty(config.issuer)
             iss = get(result, "iss", nothing)
-            if iss !== nothing && iss != config.issuer
+            if iss === nothing || iss != config.issuer
                 return AuthResult("Invalid issuer", :invalid_issuer)
             end
         end
         if !isempty(config.audience)
             aud = get(result, "aud", nothing)
-            if aud !== nothing
-                ok = aud isa AbstractString ? aud == config.audience :
-                     aud isa AbstractVector ? config.audience in aud : false
-                ok || return AuthResult("Invalid audience", :invalid_audience)
-            end
+            ok = aud isa AbstractString ? aud == config.audience :
+                 aud isa AbstractVector ? config.audience in aud : false
+            ok || return AuthResult("Invalid audience", :invalid_audience)
         end
         if haskey(result, "exp") && result["exp"] isa Number
             if round(Int, datetime2unix(now(UTC))) > result["exp"]

--- a/src/auth/token.jl
+++ b/src/auth/token.jl
@@ -10,6 +10,11 @@ using Dates: datetime2unix
 Simple token validator using a static mapping of tokens to users.
 Useful for API keys and development/testing.
 
+!!! note "Development use"
+    Lookups are plain dictionary comparisons (not constant-time) and tokens are held
+    in memory in plaintext. Intended for development and trusted static API keys, not
+    as a general-purpose production token store.
+
 # Fields
 - `tokens::Dict{String,AuthenticatedUser}`: Map of valid tokens to user info
 """
@@ -102,19 +107,21 @@ Validate JWT claims (iss, aud, exp, nbf).
 function validate_jwt_claims(claims::Dict{String,Any}, config::OAuthConfig, clock_skew::Int)
     now_ts = round(Int, datetime2unix(now(UTC)))
 
-    # Check issuer
-    if haskey(claims, "iss")
-        if claims["iss"] != config.issuer
+    # Issuer: when an issuer is configured the token MUST carry a matching `iss`.
+    # Fail closed if it is absent (a forged unsigned token must not pass by omission).
+    if !isempty(config.issuer)
+        iss = get(claims, "iss", nothing)
+        if iss === nothing || iss != config.issuer
             return AuthResult("Invalid issuer", :invalid_issuer)
         end
     end
 
-    # Check audience
-    if haskey(claims, "aud")
-        aud = claims["aud"]
-        valid_aud = if aud isa String
+    # Audience: when an audience is configured the token MUST carry a matching `aud`.
+    if !isempty(config.audience)
+        aud = get(claims, "aud", nothing)
+        valid_aud = if aud isa AbstractString
             aud == config.audience
-        elseif aud isa Vector
+        elseif aud isa AbstractVector
             config.audience in aud
         else
             false
@@ -124,12 +131,13 @@ function validate_jwt_claims(claims::Dict{String,Any}, config::OAuthConfig, cloc
         end
     end
 
-    # Check expiration
-    if haskey(claims, "exp")
-        exp = claims["exp"]
-        if exp isa Number && now_ts > exp + clock_skew
-            return AuthResult("Token expired", :expired)
-        end
+    # Expiration is REQUIRED and must be in the future (no non-expiring tokens).
+    exp = get(claims, "exp", nothing)
+    if !(exp isa Number)
+        return AuthResult("Token missing expiration", :invalid_token)
+    end
+    if now_ts > exp + clock_skew
+        return AuthResult("Token expired", :expired)
     end
 
     # Check not-before
@@ -177,11 +185,41 @@ function validate_jwt_claims(claims::Dict{String,Any}, config::OAuthConfig, cloc
     return AuthResult(user)
 end
 
-function validate_token(validator::JWTValidator, token::AbstractString, config::OAuthConfig)
-    # WARNING: Decodes payload WITHOUT signature verification.
-    # Do not use with untrusted issuers. See JWTValidator docstring.
-    claims = decode_jwt_payload(String(token))
+"""
+    decode_jwt_header(token::String) -> Union{Dict{String,Any},Nothing}
 
+Decode the JWT header (first segment) without verification. Returns `nothing` if
+the token format is invalid.
+"""
+function decode_jwt_header(token::String)
+    parts = split(token, '.')
+    length(parts) == 3 || return nothing
+    try
+        header_b64 = parts[1]
+        padding = mod(4 - mod(length(header_b64), 4), 4)
+        header_b64 = replace(header_b64 * repeat("=", padding), "-" => "+", "_" => "/")
+        return JSON3.read(String(base64decode(header_b64)), Dict{String,Any})
+    catch
+        return nothing
+    end
+end
+
+function validate_token(validator::JWTValidator, token::AbstractString, config::OAuthConfig)
+    # WARNING: Decodes payload WITHOUT cryptographic signature verification.
+    # Do not use with untrusted issuers. See JWTValidator docstring.
+    tok = String(token)
+
+    # Reject "alg: none" (unsigned) tokens outright. Even though we don't verify
+    # signatures yet, accepting alg=none is a classic JWT authentication bypass.
+    header = decode_jwt_header(tok)
+    if !isnothing(header)
+        alg = String(get(header, "alg", ""))
+        if isempty(alg) || lowercase(alg) == "none"
+            return AuthResult("Unsupported or missing JWT algorithm", :invalid_token)
+        end
+    end
+
+    claims = decode_jwt_payload(tok)
     if isnothing(claims)
         return AuthResult("Invalid JWT format", :invalid_format)
     end
@@ -245,6 +283,29 @@ function validate_token(validator::IntrospectionValidator, token::AbstractString
         # Check if token is active
         if !get(result, "active", false)
             return AuthResult("Token is not active", :invalid_token)
+        end
+
+        # Audience / issuer binding: a token that is active at the AS but was minted
+        # for a different resource must not be accepted here. Enforce when the
+        # introspection response carries the claim (RFC 7662 responses vary).
+        if !isempty(config.issuer)
+            iss = get(result, "iss", nothing)
+            if iss !== nothing && iss != config.issuer
+                return AuthResult("Invalid issuer", :invalid_issuer)
+            end
+        end
+        if !isempty(config.audience)
+            aud = get(result, "aud", nothing)
+            if aud !== nothing
+                ok = aud isa AbstractString ? aud == config.audience :
+                     aud isa AbstractVector ? config.audience in aud : false
+                ok || return AuthResult("Invalid audience", :invalid_audience)
+            end
+        end
+        if haskey(result, "exp") && result["exp"] isa Number
+            if round(Int, datetime2unix(now(UTC))) > result["exp"]
+                return AuthResult("Token expired", :expired)
+            end
         end
 
         # Build user from introspection response

--- a/src/auth/token.jl
+++ b/src/auth/token.jl
@@ -1,0 +1,283 @@
+# src/auth/token.jl
+# Token validation implementations
+
+using Base64
+using Dates: datetime2unix
+
+"""
+    SimpleTokenValidator(; tokens::Dict{String,AuthenticatedUser})
+
+Simple token validator using a static mapping of tokens to users.
+Useful for API keys and development/testing.
+
+# Fields
+- `tokens::Dict{String,AuthenticatedUser}`: Map of valid tokens to user info
+"""
+struct SimpleTokenValidator <: TokenValidator
+    tokens::Dict{String,AuthenticatedUser}
+end
+
+SimpleTokenValidator() = SimpleTokenValidator(Dict{String,AuthenticatedUser}())
+
+function Base.show(io::IO, v::SimpleTokenValidator)
+    print(io, "SimpleTokenValidator(", length(v.tokens), " tokens)")
+end
+
+"""
+    add_token!(validator::SimpleTokenValidator, token::String, user::AuthenticatedUser)
+
+Add a valid token to the validator.
+"""
+function add_token!(validator::SimpleTokenValidator, token::String, user::AuthenticatedUser)
+    validator.tokens[token] = user
+end
+
+function validate_token(validator::SimpleTokenValidator, token::AbstractString, config::OAuthConfig)
+    if haskey(validator.tokens, token)
+        return AuthResult(validator.tokens[token])
+    end
+    return AuthResult("Invalid token", :invalid_token)
+end
+
+"""
+    JWTValidator(; clock_skew_seconds::Int=60)
+
+JWT token validator that validates claims (iss, aud, exp, nbf, scope).
+
+!!! warning "No Signature Verification"
+    This validator decodes and validates JWT claims but does **not** verify
+    cryptographic signatures (JWKS/JWK). Tokens from untrusted issuers can
+    be forged. Use `IntrospectionValidator` (RFC 7662) when accepting tokens
+    from external issuers. Signature verification via JWKS may be added in a
+    future release.
+
+# Fields
+- `jwks_cache::Dict{String,Any}`: Reserved for future JWKS support
+- `clock_skew_seconds::Int`: Allowed clock skew for exp/nbf validation
+"""
+struct JWTValidator <: TokenValidator
+    jwks_cache::Dict{String,Any}
+    clock_skew_seconds::Int
+end
+
+JWTValidator(; clock_skew_seconds::Int=60) = JWTValidator(Dict{String,Any}(), clock_skew_seconds)
+
+function Base.show(io::IO, v::JWTValidator)
+    print(io, "JWTValidator(skew=", v.clock_skew_seconds, "s)")
+end
+
+"""
+    decode_jwt_payload(token::String) -> Union{Dict{String,Any},Nothing}
+
+Decode JWT payload without verification (for claim inspection).
+Returns `nothing` if token format is invalid.
+"""
+function decode_jwt_payload(token::String)
+    parts = split(token, '.')
+    if length(parts) != 3
+        return nothing
+    end
+
+    try
+        # JWT uses base64url encoding
+        payload_b64 = parts[2]
+        # Add padding if needed
+        padding = mod(4 - mod(length(payload_b64), 4), 4)
+        payload_b64 = payload_b64 * repeat("=", padding)
+        # Replace URL-safe characters
+        payload_b64 = replace(payload_b64, "-" => "+", "_" => "/")
+
+        payload_json = String(base64decode(payload_b64))
+        return JSON3.read(payload_json, Dict{String,Any})
+    catch
+        return nothing
+    end
+end
+
+"""
+    validate_jwt_claims(claims::Dict{String,Any}, config::OAuthConfig, clock_skew::Int) -> AuthResult
+
+Validate JWT claims (iss, aud, exp, nbf).
+"""
+function validate_jwt_claims(claims::Dict{String,Any}, config::OAuthConfig, clock_skew::Int)
+    now_ts = round(Int, datetime2unix(now(UTC)))
+
+    # Check issuer
+    if haskey(claims, "iss")
+        if claims["iss"] != config.issuer
+            return AuthResult("Invalid issuer", :invalid_issuer)
+        end
+    end
+
+    # Check audience
+    if haskey(claims, "aud")
+        aud = claims["aud"]
+        valid_aud = if aud isa String
+            aud == config.audience
+        elseif aud isa Vector
+            config.audience in aud
+        else
+            false
+        end
+        if !valid_aud
+            return AuthResult("Invalid audience", :invalid_audience)
+        end
+    end
+
+    # Check expiration
+    if haskey(claims, "exp")
+        exp = claims["exp"]
+        if exp isa Number && now_ts > exp + clock_skew
+            return AuthResult("Token expired", :expired)
+        end
+    end
+
+    # Check not-before
+    if haskey(claims, "nbf")
+        nbf = claims["nbf"]
+        if nbf isa Number && now_ts < nbf - clock_skew
+            return AuthResult("Token not yet valid", :not_yet_valid)
+        end
+    end
+
+    # Check required scopes
+    if !isempty(config.required_scopes)
+        token_scopes = if haskey(claims, "scope")
+            scope = claims["scope"]
+            scope isa String ? split(scope) : String[]
+        elseif haskey(claims, "scp")
+            scp = claims["scp"]
+            scp isa Vector ? String.(scp) : String[]
+        else
+            String[]
+        end
+
+        for required in config.required_scopes
+            if !(required in token_scopes)
+                return AuthResult("Missing required scope: $required", :insufficient_scope)
+            end
+        end
+    end
+
+    # Build authenticated user
+    user = AuthenticatedUser(
+        subject = get(claims, "sub", "unknown"),
+        provider = get(claims, "iss", "unknown"),
+        username = get(claims, "preferred_username", get(claims, "name", nothing)),
+        scopes = if haskey(claims, "scope")
+            String.(split(claims["scope"]))
+        elseif haskey(claims, "scp")
+            String.(claims["scp"])
+        else
+            String[]
+        end,
+        claims = claims
+    )
+
+    return AuthResult(user)
+end
+
+function validate_token(validator::JWTValidator, token::AbstractString, config::OAuthConfig)
+    # WARNING: Decodes payload WITHOUT signature verification.
+    # Do not use with untrusted issuers. See JWTValidator docstring.
+    claims = decode_jwt_payload(String(token))
+
+    if isnothing(claims)
+        return AuthResult("Invalid JWT format", :invalid_format)
+    end
+
+    # Validate claims
+    return validate_jwt_claims(claims, config, validator.clock_skew_seconds)
+end
+
+"""
+    IntrospectionValidator(; client_id=nothing, client_secret=nothing)
+
+Token validator using OAuth 2.0 Token Introspection (RFC 7662).
+Used for opaque tokens that cannot be validated locally.
+
+# Fields
+- `client_id::Union{String,Nothing}`: Client ID for introspection auth
+- `client_secret::Union{String,Nothing}`: Client secret for introspection auth
+"""
+struct IntrospectionValidator <: TokenValidator
+    client_id::Union{String,Nothing}
+    client_secret::Union{String,Nothing}
+end
+
+IntrospectionValidator(; client_id=nothing, client_secret=nothing) =
+    IntrospectionValidator(client_id, client_secret)
+
+function Base.show(io::IO, v::IntrospectionValidator)
+    has_creds = !isnothing(v.client_id)
+    print(io, "IntrospectionValidator(", has_creds ? "with credentials" : "no credentials", ")")
+end
+
+function validate_token(validator::IntrospectionValidator, token::AbstractString, config::OAuthConfig)
+    if isnothing(config.introspection_endpoint)
+        return AuthResult("Introspection endpoint not configured", :configuration_error)
+    end
+
+    try
+        # Build introspection request
+        headers = ["Content-Type" => "application/x-www-form-urlencoded"]
+
+        # Add client credentials if configured
+        if !isnothing(validator.client_id) && !isnothing(validator.client_secret)
+            auth = base64encode("$(validator.client_id):$(validator.client_secret)")
+            push!(headers, "Authorization" => "Basic $auth")
+        end
+
+        body = "token=$(HTTP.URIs.escapeuri(String(token)))"
+
+        response = HTTP.post(
+            config.introspection_endpoint,
+            headers,
+            body
+        )
+
+        if response.status != 200
+            return AuthResult("Introspection request failed", :introspection_error)
+        end
+
+        result = JSON3.read(String(response.body), Dict{String,Any})
+
+        # Check if token is active
+        if !get(result, "active", false)
+            return AuthResult("Token is not active", :invalid_token)
+        end
+
+        # Build user from introspection response
+        user = AuthenticatedUser(
+            subject = get(result, "sub", get(result, "username", "unknown")),
+            provider = get(result, "iss", config.issuer),
+            username = get(result, "username", nothing),
+            scopes = if haskey(result, "scope")
+                String.(split(result["scope"]))
+            else
+                String[]
+            end,
+            claims = result
+        )
+
+        # Check required scopes
+        if !isempty(config.required_scopes)
+            for required in config.required_scopes
+                if !(required in user.scopes)
+                    return AuthResult("Missing required scope: $required", :insufficient_scope)
+                end
+            end
+        end
+
+        return AuthResult(user)
+
+    catch e
+        if e isa HTTP.StatusError
+            return AuthResult("Introspection request failed: HTTP $(e.status)", :introspection_error)
+        elseif e isa HTTP.RequestError
+            return AuthResult("Introspection request failed: $(e.error)", :introspection_error)
+        else
+            rethrow(e)
+        end
+    end
+end

--- a/src/core/server.jl
+++ b/src/core/server.jl
@@ -43,7 +43,8 @@ Process an incoming JSON-RPC message and generate an appropriate response.
 # Returns
 - `Union{String,Nothing}`: A serialized response string or nothing for notifications
 """
-function process_message(server::Server, state::ServerState, message::String)::Union{String,Nothing}
+function process_message(server::Server, state::ServerState, message::String;
+                         authenticated_user=nothing)::Union{String,Nothing}
     # Parse the incoming message
     parsed = try
         @debug "Parsing message"
@@ -70,10 +71,10 @@ function process_message(server::Server, state::ServerState, message::String)::U
     try
         if parsed isa JSONRPCRequest
             # Handle request
-            response = handle_request(server, state, parsed)
+            response = handle_request(server, state, parsed; authenticated_user=authenticated_user)
             return serialize_message(response) # Make sure to serialize the response
         elseif parsed isa JSONRPCNotification
-            handle_notification(RequestContext(server=server, state=state), parsed)
+            handle_notification(RequestContext(server=server, state=state, authenticated_user=authenticated_user), parsed)
             return nothing
         end
     catch e
@@ -158,7 +159,7 @@ function run_server_loop(server::Server, state::ServerState)
             
             # Process the message
             @debug "Processing message" raw=message
-            response = process_message(server, state, message)
+            response = process_message(server, state, message; authenticated_user=pending_auth_context(transport))
             
             if !isnothing(response)
                 @debug "Sending response" response=response

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -25,6 +25,7 @@ Base.@kwdef mutable struct RequestContext
     state::ServerState = ServerState()
     request_id::Union{RequestId,Nothing} = nothing
     progress_token::Union{ProgressToken,Nothing} = nothing
+    authenticated_user::Union{AuthenticatedUser,Nothing} = nothing  # per-request identity from HTTP auth, else nothing
 end
 
 """
@@ -549,8 +550,11 @@ function handle_call_tool(ctx::RequestContext, params::CallToolParams)::HandlerR
             end
         end
         
-        # Call the tool handler with the arguments
-        result = tool.handler(args)
+        # Call the tool handler. Handlers may opt into a context-aware form
+        # `handler(args, ctx)` to access `ctx.authenticated_user` etc.; the plain
+        # `handler(args)` form keeps working. Dispatch by applicability (not by
+        # catching MethodError, which would mask errors thrown inside a handler).
+        result = applicable(tool.handler, args, ctx) ? tool.handler(args, ctx) : tool.handler(args)
         
         # Check if the handler returned a complete CallToolResult
         if result isa CallToolResult
@@ -746,12 +750,14 @@ Any exceptions thrown during processing are caught and converted to INTERNAL_ERR
 # Returns
 - `Response`: Either a successful response or an error response depending on the handler result
 """
-function handle_request(server::Server, state::ServerState, request::Request)::Response
+function handle_request(server::Server, state::ServerState, request::Request;
+                        authenticated_user::Union{AuthenticatedUser,Nothing}=nothing)::Response
     ctx = RequestContext(
         server=server,
         state=state,
         request_id=request.id,
-        progress_token=request.meta.progress_token
+        progress_token=request.meta.progress_token,
+        authenticated_user=authenticated_user
     )
 
     try

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -25,7 +25,7 @@ Base.@kwdef mutable struct RequestContext
     state::ServerState = ServerState()
     request_id::Union{RequestId,Nothing} = nothing
     progress_token::Union{ProgressToken,Nothing} = nothing
-    authenticated_user::Union{AuthenticatedUser,Nothing} = nothing  # per-request identity from HTTP auth, else nothing
+    authenticated_user::Union{AuthenticatedUser,Nothing} = nothing  # per-request identity from HTTP auth, else nothing; treat as read-only (may be shared from a validator cache)
 end
 
 """

--- a/src/transports/base.jl
+++ b/src/transports/base.jl
@@ -36,6 +36,16 @@ Read a single message from the transport.
 function read_message end
 
 """
+    pending_auth_context(transport::Transport) -> Union{Nothing,Any}
+
+Return the authenticated user associated with the message most recently read from
+`transport`, or `nothing` when the transport has no per-request authentication
+(e.g. stdio). Transports that authenticate requests override this; the default is
+`nothing`.
+"""
+pending_auth_context(::Transport) = nothing
+
+"""
     write_message(transport::Transport, message::String) -> Nothing
 
 Write a message to the transport.

--- a/src/transports/http.jl
+++ b/src/transports/http.jl
@@ -5,6 +5,20 @@ using JSON3
 using UUIDs: uuid4
 
 """
+    QueuedHttpRequest(id, body, user)
+
+Envelope for a request on the HTTP work queue. Carries the per-request
+authenticated `user` (or `nothing`) from the concurrent connection handler to the
+single server loop, so auth identity travels with the request rather than via
+shared transport state.
+"""
+struct QueuedHttpRequest
+    id::String
+    body::String
+    user::Union{AuthenticatedUser,Nothing}
+end
+
+"""
     HttpTransport(; host::String="127.0.0.1", port::Int=8080, endpoint::String="/")
 
 Transport implementation following the MCP Streamable HTTP specification (2025-06-18).
@@ -18,7 +32,7 @@ Supports Server-Sent Events (SSE) for streaming and session management.
 - `connected::Bool`: Connection status
 - `server_task::Union{Task,Nothing}`: Server task handle
 - `active_streams::Dict{String,HTTP.Stream}`: Active streaming connections
-- `request_queue::Channel{Tuple{String,String}}`: Queue for incoming requests (id, message)
+- `request_queue::Channel{QueuedHttpRequest}`: Queue for incoming requests (id, body, auth user)
 - `response_channels::Dict{String,Channel{String}}`: Response channels per request
 """
 mutable struct HttpTransport <: Transport
@@ -30,10 +44,11 @@ mutable struct HttpTransport <: Transport
     server_task::Union{Task,Nothing}
     active_streams::Dict{String,HTTP.Stream}
     sse_streams::Dict{String,HTTP.Stream}  # SSE connections
-    request_queue::Channel{Tuple{String,String}}
+    request_queue::Channel{QueuedHttpRequest}
     response_channels::Dict{String,Channel{String}}
     notification_queue::Channel{String}  # For SSE notifications
     current_request_id::Union{String,Nothing}
+    current_request_auth::Union{AuthenticatedUser,Nothing}  # Auth user of the message just read; set in the single server loop, never across connections
     session_id::Union{String,Nothing}  # Session management
     session_required::Bool  # Whether session is required after init
     protocol_version::String  # MCP protocol version
@@ -41,7 +56,6 @@ mutable struct HttpTransport <: Transport
     allowed_origins::Vector{String}  # CORS security
     auth::Union{AuthMiddleware,Nothing}  # OAuth Resource Server token validation (nothing = disabled)
     resource_metadata::Union{ProtectedResourceMetadata,Nothing}  # RFC 9728 Protected Resource Metadata
-    current_user::Union{AuthenticatedUser,Nothing}  # Authenticated user for the in-flight request
 
     function HttpTransport(;
         host::String="127.0.0.1",
@@ -62,18 +76,18 @@ mutable struct HttpTransport <: Transport
             nothing,
             Dict{String,HTTP.Stream}(),
             Dict{String,HTTP.Stream}(),  # SSE streams
-            Channel{Tuple{String,String}}(32),  # Buffer up to 32 requests
+            Channel{QueuedHttpRequest}(32),  # Buffer up to 32 requests
             Dict{String,Channel{String}}(),
             Channel{String}(100),  # Notification queue
-            nothing,
+            nothing,  # current_request_id
+            nothing,  # current_request_auth
             nothing,  # No session initially
             session_required,
             protocol_version,
             0,  # Event counter starts at 0
             allowed_origins,
             auth,
-            resource_metadata,
-            nothing  # No authenticated user initially
+            resource_metadata
         )
     end
 end
@@ -304,6 +318,9 @@ function handle_request(transport::HttpTransport, stream::HTTP.Stream)
     # OAuth Resource Server: require a valid bearer token when auth is configured.
     # Applies to every request to the MCP endpoint (POST and SSE GET); the
     # well-known discovery endpoint above is exempt so clients can bootstrap.
+    # The validated user travels with the request via QueuedHttpRequest (below),
+    # not via shared transport state, so concurrent requests can't clobber it.
+    authenticated_user = nothing
     if !isnothing(transport.auth)
         auth_header_raw = HTTP.header(request, "Authorization", "")
         auth_header = isempty(auth_header_raw) ? nothing : String(auth_header_raw)
@@ -328,7 +345,7 @@ function handle_request(transport::HttpTransport, stream::HTTP.Stream)
             write(stream, body)
             return nothing
         end
-        transport.current_user = auth_result.user
+        authenticated_user = auth_result.user
     end
 
     # Handle GET requests for SSE notification stream
@@ -488,7 +505,7 @@ function handle_request(transport::HttpTransport, stream::HTTP.Stream)
             HTTP.startwrite(stream)  # Ensure headers are sent
             
             # Still queue the notification for processing
-            put!(transport.request_queue, ("notification-" * string(uuid4()), body))
+            put!(transport.request_queue, QueuedHttpRequest("notification-" * string(uuid4()), body, authenticated_user))
             return nothing
         end
         
@@ -501,7 +518,7 @@ function handle_request(transport::HttpTransport, stream::HTTP.Stream)
         transport.active_streams[request_id] = stream
         
         # Queue the request for processing
-        put!(transport.request_queue, (request_id, body))
+        put!(transport.request_queue, QueuedHttpRequest(request_id, body, authenticated_user))
         
         # Wait for the single response
         try
@@ -713,12 +730,15 @@ function read_message(transport::HttpTransport)::Union{String,Nothing}
     
     try
         # Block until request is available
-        request_id, message = take!(transport.request_queue)
-        
-        # Store the current request ID for response correlation
-        transport.current_request_id = request_id
-        
-        return message
+        env = take!(transport.request_queue)
+
+        # Store the current request ID for response correlation, and the
+        # per-request authenticated user (consumed by the single server loop via
+        # pending_auth_context before the next read — never shared across connections).
+        transport.current_request_id = env.id
+        transport.current_request_auth = env.user
+
+        return env.body
     catch e
         if e isa InvalidStateException && !isopen(transport.request_queue)
             # Channel is closed, transport is shutting down
@@ -862,19 +882,15 @@ function Base.show(io::IO, transport::HttpTransport)
 end
 
 """
-    get_authenticated_user(transport::HttpTransport) -> Union{AuthenticatedUser,Nothing}
+    pending_auth_context(transport::HttpTransport) -> Union{AuthenticatedUser,Nothing}
 
-Return the user authenticated for the in-flight request, or `nothing` when auth is
-disabled or the request was unauthenticated.
-
-# Arguments
-- `transport::HttpTransport`: The transport instance
-
-# Returns
-- `Union{AuthenticatedUser,Nothing}`: The authenticated user, or `nothing`
+Return the authenticated user of the message most recently read from the queue (set
+in `read_message`, consumed immediately by the single server loop). This is how the
+per-request identity reaches `RequestContext.authenticated_user`; handlers should read
+it from the request context, not from the transport.
 """
-function get_authenticated_user(transport::HttpTransport)::Union{AuthenticatedUser,Nothing}
-    return transport.current_user
+function pending_auth_context(transport::HttpTransport)::Union{AuthenticatedUser,Nothing}
+    return transport.current_request_auth
 end
 
 """

--- a/src/transports/http.jl
+++ b/src/transports/http.jl
@@ -39,14 +39,19 @@ mutable struct HttpTransport <: Transport
     protocol_version::String  # MCP protocol version
     event_counter::Int64  # SSE event IDs
     allowed_origins::Vector{String}  # CORS security
-    
-    function HttpTransport(; 
-        host::String="127.0.0.1", 
-        port::Int=8080, 
+    auth::Union{AuthMiddleware,Nothing}  # OAuth Resource Server token validation (nothing = disabled)
+    resource_metadata::Union{ProtectedResourceMetadata,Nothing}  # RFC 9728 Protected Resource Metadata
+    current_user::Union{AuthenticatedUser,Nothing}  # Authenticated user for the in-flight request
+
+    function HttpTransport(;
+        host::String="127.0.0.1",
+        port::Int=8080,
         endpoint::String="/",
         allowed_origins::Vector{String}=String[],
         protocol_version::String=LATEST_PROTOCOL_VERSION,
-        session_required::Bool=false
+        session_required::Bool=false,
+        auth::Union{AuthMiddleware,Nothing}=nothing,
+        resource_metadata::Union{ProtectedResourceMetadata,Nothing}=nothing
     )
         new(
             host,
@@ -65,7 +70,10 @@ mutable struct HttpTransport <: Transport
             session_required,
             protocol_version,
             0,  # Event counter starts at 0
-            allowed_origins
+            allowed_origins,
+            auth,
+            resource_metadata,
+            nothing  # No authenticated user initially
         )
     end
 end
@@ -262,7 +270,29 @@ function handle_request(transport::HttpTransport, stream::HTTP.Stream)
     method = HTTP.method(request)
     target = request.target
     path = HTTP.URI(target).path
-    
+
+    # OAuth Resource Server: serve Protected Resource Metadata discovery (RFC 9728).
+    # Public endpoint — intentionally reachable without authentication.
+    if method == "GET" && path == WELL_KNOWN_PATH
+        if !isnothing(transport.resource_metadata)
+            status, body, headers = handle_well_known_request(transport.resource_metadata)
+            HTTP.setstatus(stream, status)
+            for (k, v) in headers
+                HTTP.setheader(stream, k => v)
+            end
+            HTTP.setheader(stream, "Content-Length" => string(length(body)))
+            HTTP.startwrite(stream)
+            write(stream, body)
+        else
+            HTTP.setstatus(stream, 404)
+            HTTP.setheader(stream, "Content-Type" => "text/plain")
+            HTTP.setheader(stream, "Content-Length" => "9")
+            HTTP.startwrite(stream)
+            write(stream, "Not Found")
+        end
+        return nothing
+    end
+
     # Handle both POST and GET requests to our endpoint
     if path != transport.endpoint
         HTTP.setstatus(stream, 404)
@@ -270,7 +300,37 @@ function handle_request(transport::HttpTransport, stream::HTTP.Stream)
         write(stream, "Not Found")
         return nothing
     end
-    
+
+    # OAuth Resource Server: require a valid bearer token when auth is configured.
+    # Applies to every request to the MCP endpoint (POST and SSE GET); the
+    # well-known discovery endpoint above is exempt so clients can bootstrap.
+    if !isnothing(transport.auth)
+        auth_header_raw = HTTP.header(request, "Authorization", "")
+        auth_header = isempty(auth_header_raw) ? nothing : String(auth_header_raw)
+        auth_result = authenticate_request(transport.auth, auth_header)
+        if !auth_result.success
+            resource_metadata_url = if !isnothing(transport.resource_metadata)
+                "$(transport.resource_metadata.resource)/.well-known/oauth-protected-resource"
+            else
+                nothing
+            end
+            status, body, headers = auth_error_response(
+                auth_result.error_code,
+                auth_result.error;
+                resource_metadata_url=resource_metadata_url
+            )
+            HTTP.setstatus(stream, status)
+            for (k, v) in headers
+                HTTP.setheader(stream, k => v)
+            end
+            HTTP.setheader(stream, "Content-Length" => string(length(body)))
+            HTTP.startwrite(stream)
+            write(stream, body)
+            return nothing
+        end
+        transport.current_user = auth_result.user
+    end
+
     # Handle GET requests for SSE notification stream
     if method == "GET"
         accept_header = HTTP.header(request, "Accept", "")
@@ -799,4 +859,35 @@ function Base.show(io::IO, transport::HttpTransport)
     status = transport.connected ? "connected" : "disconnected"
     active = length(transport.active_streams)
     print(io, "HttpTransport(http://$(transport.host):$(transport.port)$(transport.endpoint), $status, $active active)")
+end
+
+"""
+    get_authenticated_user(transport::HttpTransport) -> Union{AuthenticatedUser,Nothing}
+
+Return the user authenticated for the in-flight request, or `nothing` when auth is
+disabled or the request was unauthenticated.
+
+# Arguments
+- `transport::HttpTransport`: The transport instance
+
+# Returns
+- `Union{AuthenticatedUser,Nothing}`: The authenticated user, or `nothing`
+"""
+function get_authenticated_user(transport::HttpTransport)::Union{AuthenticatedUser,Nothing}
+    return transport.current_user
+end
+
+"""
+    is_auth_enabled(transport::HttpTransport) -> Bool
+
+Return whether OAuth Resource Server token validation is enabled on this transport.
+
+# Arguments
+- `transport::HttpTransport`: The transport instance
+
+# Returns
+- `Bool`: true if an enabled `AuthMiddleware` is configured
+"""
+function is_auth_enabled(transport::HttpTransport)::Bool
+    return !isnothing(transport.auth) && transport.auth.enabled
 end

--- a/test/auth/test_auth.jl
+++ b/test/auth/test_auth.jl
@@ -1,0 +1,322 @@
+@testset "Authentication Framework" begin
+    @testset "AuthenticatedUser" begin
+        user = AuthenticatedUser(
+            subject = "user123",
+            provider = "github",
+            username = "testuser",
+            scopes = ["read:user", "repo"],
+            claims = Dict{String,Any}("email" => "test@example.com")
+        )
+
+        @test user.subject == "user123"
+        @test user.provider == "github"
+        @test user.username == "testuser"
+        @test "read:user" in user.scopes
+        @test user.claims["email"] == "test@example.com"
+    end
+
+    @testset "OAuthConfig" begin
+        config = OAuthConfig(
+            issuer = "https://github.com",
+            audience = "my-mcp-server",
+            required_scopes = ["read:user"]
+        )
+
+        @test config.issuer == "https://github.com"
+        @test config.audience == "my-mcp-server"
+        @test "read:user" in config.required_scopes
+    end
+
+    @testset "AuthResult" begin
+        # Success result
+        user = AuthenticatedUser(subject = "test", provider = "test")
+        success = AuthResult(user)
+        @test success.success == true
+        @test success.user.subject == "test"
+        @test isnothing(success.error)
+
+        # Error result
+        failure = AuthResult("Invalid token", :invalid_token)
+        @test failure.success == false
+        @test isnothing(failure.user)
+        @test failure.error == "Invalid token"
+        @test failure.error_code == :invalid_token
+    end
+
+    @testset "extract_bearer_token" begin
+        @test ModelContextProtocol.extract_bearer_token("Bearer abc123") == "abc123"
+        @test ModelContextProtocol.extract_bearer_token("Bearer  token-with-spaces  ") == "token-with-spaces"
+        @test isnothing(ModelContextProtocol.extract_bearer_token("Basic abc123"))
+        @test isnothing(ModelContextProtocol.extract_bearer_token("abc123"))
+        @test isnothing(ModelContextProtocol.extract_bearer_token(""))
+    end
+
+    @testset "SimpleTokenValidator" begin
+        validator = SimpleTokenValidator()
+
+        # Add a token
+        user = AuthenticatedUser(
+            subject = "user1",
+            provider = "api_key",
+            username = "testuser"
+        )
+        ModelContextProtocol.add_token!(validator, "sk-test123", user)
+
+        config = OAuthConfig(issuer = "local", audience = "local")
+
+        # Valid token
+        result = validate_token(validator, "sk-test123", config)
+        @test result.success == true
+        @test result.user.subject == "user1"
+
+        # Invalid token
+        result = validate_token(validator, "invalid", config)
+        @test result.success == false
+        @test result.error_code == :invalid_token
+    end
+
+    @testset "create_simple_auth" begin
+        auth = create_simple_auth(Dict(
+            "key1" => "user1",
+            "key2" => "user2"
+        ))
+
+        @test auth.enabled == true
+
+        # Test with valid token
+        result = authenticate_request(auth, "Bearer key1")
+        @test result.success == true
+        @test result.user.username == "user1"
+
+        # Test with invalid token
+        result = authenticate_request(auth, "Bearer invalid")
+        @test result.success == false
+    end
+
+    @testset "disable_auth" begin
+        auth = disable_auth()
+        @test auth.enabled == false
+
+        # All requests should succeed with anonymous user
+        result = authenticate_request(auth, nothing)
+        @test result.success == true
+        @test result.user.subject == "anonymous"
+
+        result = authenticate_request(auth, "Bearer anything")
+        @test result.success == true
+    end
+
+    @testset "check_allowlist" begin
+        user1 = AuthenticatedUser(subject = "sub1", provider = "test", username = "user1")
+        user2 = AuthenticatedUser(subject = "sub2", provider = "test", username = nothing)
+
+        allowlist = Set(["user1", "sub2"])
+
+        # User with matching username
+        @test ModelContextProtocol.check_allowlist(user1, allowlist) == true
+
+        # User with matching subject (no username)
+        @test ModelContextProtocol.check_allowlist(user2, allowlist) == true
+
+        # User not in allowlist
+        user3 = AuthenticatedUser(subject = "sub3", provider = "test", username = "user3")
+        @test ModelContextProtocol.check_allowlist(user3, allowlist) == false
+    end
+
+    @testset "AuthMiddleware with allowlist" begin
+        auth = create_simple_auth(
+            Dict("key1" => "allowed_user", "key2" => "blocked_user"),
+            allowlist = Set(["allowed_user"])
+        )
+
+        # Allowed user
+        result = authenticate_request(auth, "Bearer key1")
+        @test result.success == true
+
+        # Blocked user (valid token but not in allowlist)
+        result = authenticate_request(auth, "Bearer key2")
+        @test result.success == false
+        @test result.error_code == :forbidden
+    end
+
+    @testset "authenticate_request error cases" begin
+        auth = create_simple_auth(Dict("valid" => "user"))
+
+        # Missing header
+        result = authenticate_request(auth, nothing)
+        @test result.success == false
+        @test result.error_code == :missing_token
+
+        # Empty header
+        result = authenticate_request(auth, "")
+        @test result.success == false
+        @test result.error_code == :missing_token
+
+        # Invalid format (not Bearer)
+        result = authenticate_request(auth, "Basic abc123")
+        @test result.success == false
+        @test result.error_code == :invalid_format
+    end
+
+    @testset "ProtectedResourceMetadata" begin
+        metadata = create_protected_resource_metadata(
+            "https://mcp.example.com",
+            ["https://github.com/login/oauth"],
+            scopes = ["read:user", "repo"]
+        )
+
+        @test metadata.resource == "https://mcp.example.com"
+        @test "https://github.com/login/oauth" in metadata.authorization_servers
+        @test "read:user" in metadata.scopes_supported
+        @test "header" in metadata.bearer_methods_supported
+    end
+
+    @testset "create_github_resource_metadata" begin
+        metadata = create_github_resource_metadata(
+            "https://mcp.lidkelab.org",
+            scopes = ["read:user", "read:org"]
+        )
+
+        @test metadata.resource == "https://mcp.lidkelab.org"
+        @test ModelContextProtocol.GitHubAuthorizationServer in metadata.authorization_servers
+        @test "read:user" in metadata.scopes_supported
+    end
+
+    @testset "metadata_to_json" begin
+        metadata = create_protected_resource_metadata(
+            "https://example.com",
+            ["https://auth.example.com"]
+        )
+
+        json = ModelContextProtocol.metadata_to_json(metadata)
+        parsed = JSON3.read(json)
+
+        @test parsed["resource"] == "https://example.com"
+        @test "https://auth.example.com" in parsed["authorization_servers"]
+    end
+
+    @testset "JWTValidator - decode_jwt_payload" begin
+        # Create a simple test JWT (header.payload.signature)
+        # Payload: {"sub": "user123", "iss": "test", "exp": 9999999999}
+        payload_json = """{"sub":"user123","iss":"test","exp":9999999999}"""
+        payload_b64 = Base64.base64encode(payload_json)
+        # Convert to URL-safe base64
+        payload_b64 = replace(payload_b64, "+" => "-", "/" => "_")
+        payload_b64 = rstrip(payload_b64, '=')
+
+        # Fake header and signature
+        header_b64 = Base64.base64encode("""{"alg":"HS256","typ":"JWT"}""")
+        header_b64 = replace(header_b64, "+" => "-", "/" => "_")
+        header_b64 = rstrip(header_b64, '=')
+
+        test_jwt = "$(header_b64).$(payload_b64).fake_signature"
+
+        claims = ModelContextProtocol.decode_jwt_payload(test_jwt)
+        @test !isnothing(claims)
+        @test claims["sub"] == "user123"
+        @test claims["iss"] == "test"
+
+        # Invalid JWT format
+        @test isnothing(ModelContextProtocol.decode_jwt_payload("not.a.jwt.token"))
+        @test isnothing(ModelContextProtocol.decode_jwt_payload("invalid"))
+    end
+
+    @testset "auth_error_response" begin
+        # 401 errors
+        status, body, headers = ModelContextProtocol.auth_error_response(:invalid_token, "Token is invalid")
+        @test status == 401
+        @test haskey(headers, "WWW-Authenticate")
+        @test occursin("invalid_token", headers["WWW-Authenticate"])
+
+        # 403 errors
+        status, _, _ = ModelContextProtocol.auth_error_response(:forbidden, "User not allowed")
+        @test status == 403
+
+        status, _, headers = ModelContextProtocol.auth_error_response(:insufficient_scope, "Missing scope")
+        @test status == 403
+        @test occursin("insufficient_scope", headers["WWW-Authenticate"])
+    end
+
+    @testset "GitHub OAuth Provider" begin
+        @testset "GitHubOAuthValidator" begin
+            validator = GitHubOAuthValidator(cache_ttl_seconds = 120)
+
+            @test validator.cache_ttl_seconds == 120
+            @test isempty(validator.user_cache)
+        end
+
+        @testset "create_github_auth with allowlist" begin
+            auth = create_github_auth(
+                allowed_users = ["user1", "user2", "user3"]
+            )
+
+            @test auth.enabled == true
+            @test !isnothing(auth.allowlist)
+            @test "user1" in auth.allowlist
+            @test "user2" in auth.allowlist
+            @test "user3" in auth.allowlist
+            @test auth.config.issuer == "https://github.com"
+        end
+
+        @testset "create_github_auth with Set allowlist" begin
+            auth = create_github_auth(
+                allowed_users = Set(["userA", "userB"])
+            )
+
+            @test auth.enabled == true
+            @test "userA" in auth.allowlist
+            @test "userB" in auth.allowlist
+        end
+
+        @testset "create_github_auth without allowlist" begin
+            auth = create_github_auth()
+
+            @test auth.enabled == true
+            @test isnothing(auth.allowlist)  # No allowlist = allow all authenticated
+        end
+
+        @testset "create_github_auth with org requirement" begin
+            auth = create_github_auth(
+                required_org = "JuliaSMLM"
+            )
+
+            @test auth.enabled == true
+            # The validator should be GitHubOAuthValidatorWithOrg
+            @test auth.validator isa ModelContextProtocol.GitHubOAuthValidatorWithOrg
+            @test auth.validator.required_org == "JuliaSMLM"
+        end
+
+        @testset "clear_cache!" begin
+            validator = GitHubOAuthValidator()
+
+            # Manually add to cache for testing
+            user = AuthenticatedUser(subject = "123", provider = "github", username = "test")
+            validator.user_cache["test-token"] = (user, Dates.now(Dates.UTC))
+
+            @test !isempty(validator.user_cache)
+
+            clear_cache!(validator)
+
+            @test isempty(validator.user_cache)
+        end
+
+        @testset "GITHUB_API_URL constant" begin
+            @test ModelContextProtocol.GITHUB_API_URL == "https://api.github.com"
+        end
+
+        @testset "GitHub auth integration without real token" begin
+            # Test that validation fails gracefully without valid token
+            auth = create_github_auth(
+                allowed_users = ["user1"]
+            )
+
+            # Without a real GitHub token, validation should fail
+            # Note: This doesn't actually call GitHub API in test
+            result = authenticate_request(auth, "Bearer fake-token-12345")
+
+            # The request will fail because we can't reach GitHub API or token is invalid
+            @test result.success == false
+            @test result.error_code == :invalid_token
+        end
+    end
+end

--- a/test/auth/test_auth.jl
+++ b/test/auth/test_auth.jl
@@ -320,3 +320,71 @@
         end
     end
 end
+
+@testset "OAuth Resource Server hardening" begin
+    _b64url(s) = replace(base64encode(s), "+" => "-", "/" => "_", "=" => "")
+    _mkjwt(header, payload) = "$(_b64url(JSON3.write(header))).$(_b64url(JSON3.write(payload))).sig"
+    cfg = OAuthConfig(issuer = "https://issuer.example", audience = "my-mcp")
+    v = JWTValidator()
+    future = round(Int, datetime2unix(now(UTC))) + 3600
+    past = round(Int, datetime2unix(now(UTC))) - 3600
+
+    @testset "create_auth_middleware requires an explicit validator" begin
+        @test_throws UndefKeywordError create_auth_middleware(cfg)
+        @test create_auth_middleware(cfg; validator = v) isa AuthMiddleware
+    end
+
+    @testset "JWT validator fails closed" begin
+        # alg=none is rejected outright (classic bypass)
+        @test validate_token(v, _mkjwt(Dict("alg"=>"none"),
+            Dict("iss"=>"https://issuer.example","aud"=>"my-mcp","exp"=>future,"sub"=>"u")), cfg).error_code == :invalid_token
+        # Missing exp rejected (no non-expiring tokens)
+        @test validate_token(v, _mkjwt(Dict("alg"=>"RS256"),
+            Dict("iss"=>"https://issuer.example","aud"=>"my-mcp","sub"=>"u")), cfg).error_code == :invalid_token
+        # Expired rejected
+        @test validate_token(v, _mkjwt(Dict("alg"=>"RS256"),
+            Dict("iss"=>"https://issuer.example","aud"=>"my-mcp","exp"=>past,"sub"=>"u")), cfg).error_code == :expired
+        # Wrong / missing issuer rejected when configured
+        @test validate_token(v, _mkjwt(Dict("alg"=>"RS256"),
+            Dict("iss"=>"https://evil","aud"=>"my-mcp","exp"=>future,"sub"=>"u")), cfg).error_code == :invalid_issuer
+        @test validate_token(v, _mkjwt(Dict("alg"=>"RS256"),
+            Dict("aud"=>"my-mcp","exp"=>future,"sub"=>"u")), cfg).error_code == :invalid_issuer
+        # Wrong audience rejected
+        @test validate_token(v, _mkjwt(Dict("alg"=>"RS256"),
+            Dict("iss"=>"https://issuer.example","aud"=>"other","exp"=>future,"sub"=>"u")), cfg).error_code == :invalid_audience
+        # Fully valid claims pass (claims-only; signatures still not verified)
+        ok = validate_token(v, _mkjwt(Dict("alg"=>"RS256"),
+            Dict("iss"=>"https://issuer.example","aud"=>"my-mcp","exp"=>future,"sub"=>"u","preferred_username"=>"alice")), cfg)
+        @test ok.success
+        @test ok.user.username == "alice"
+    end
+end
+
+@testset "Per-request auth context + ctx-aware handlers" begin
+    server = mcp_server(name = "ctx-test", description = "", tools = [
+        MCPTool(name = "whoami", description = "echo the authenticated user",
+                handler = (args, ctx) -> TextContent(text = isnothing(ctx.authenticated_user) ? "anon" : ctx.authenticated_user.username),
+                parameters = ToolParameter[]),
+        MCPTool(name = "plain", description = "no ctx",
+                handler = (args) -> TextContent(text = "ok"),
+                parameters = ToolParameter[]),
+    ])
+    state = ServerState()
+    whoami(user) = JSON3.read(process_message(server, state,
+        """{"jsonrpc":"2.0","method":"tools/call","params":{"name":"whoami","arguments":{}},"id":1}""";
+        authenticated_user = user)).result.content[1].text
+
+    # Plain handler(args) still works
+    rplain = JSON3.read(process_message(server, state,
+        """{"jsonrpc":"2.0","method":"tools/call","params":{"name":"plain","arguments":{}},"id":1}"""))
+    @test rplain.result.content[1].text == "ok"
+
+    # ctx-aware handler sees the per-request user; interleaving must not leak identity
+    alice = AuthenticatedUser(subject = "1", provider = "test", username = "alice")
+    bob   = AuthenticatedUser(subject = "2", provider = "test", username = "bob")
+    @test whoami(nothing) == "anon"
+    @test whoami(alice) == "alice"
+    @test whoami(bob) == "bob"
+    @test whoami(alice) == "alice"
+    @test whoami(nothing) == "anon"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 using ModelContextProtocol
-using JSON3, URIs, DataStructures, Logging, Base64, HTTP
+using JSON3, URIs, DataStructures, Logging, Base64, HTTP, Dates
 using OrderedCollections: LittleDict
 
 # Only import internals that are actually needed for specific tests
@@ -14,6 +14,9 @@ using ModelContextProtocol: HandlerResult, CallToolParams, ListResourcesParams, 
 using ModelContextProtocol: user, assistant  # For role constants
 using ModelContextProtocol: PromptCapability  # For server tests
 using ModelContextProtocol: MCPLogger  # For logging tests
+using ModelContextProtocol: add_token!, decode_jwt_payload, auth_error_response, check_allowlist  # For OAuth Resource Server tests
+using ModelContextProtocol: GitHubOAuthValidatorWithOrg, GITHUB_API_URL  # For GitHub validator tests
+using ModelContextProtocol: WELL_KNOWN_PATH, handle_well_known_request  # For protected-resource-metadata tests
 
 # End-to-end tests spawn the example servers as real subprocesses (slow JIT
 # startup), so they run locally by default and are skipped on CI. Force either
@@ -38,6 +41,7 @@ const RUN_E2E = get(ENV, "MCP_TEST_E2E", ON_CI ? "false" : "true") == "true"
     include("transports/test_http.jl")
     include("transports/test_streamable_http.jl")
     include("integration/full_server.jl")
+    include("auth/test_auth.jl")
 
     if RUN_E2E
         include("e2e/test_protocol_e2e.jl")


### PR DESCRIPTION
## Summary

OAuth **Resource Server** for the Streamable HTTP transport — validates incoming bearer tokens and serves RFC 9728 Protected Resource Metadata. Extracted from the stalled #27 and then **redesigned per Codex review**. It does not issue tokens; the OAuth 2.1 Authorization Server is a later slice. Targets the unreleased 0.5.0.

## What's included

- **`src/auth/`** (RS only): validators (`SimpleTokenValidator`, `JWTValidator`, `IntrospectionValidator`, `GitHubOAuthValidator`), `AuthMiddleware`, RFC 9728 metadata. Zero dependency on the `oauth_server/` (AS) tree; no new Julia deps.
- **HTTP transport**: `HttpTransport(; auth, resource_metadata)`. Unset ⇒ unauthenticated (default unchanged; existing tests untouched). When set, every MCP-endpoint request needs a valid bearer token; `/.well-known/oauth-protected-resource` is public; 401/403 carry `WWW-Authenticate`.

## Redesign + hardening (from Codex review)

- **Per-request auth context** (replaces a transport-global identity race): the user is carried in a `QueuedHttpRequest` envelope → `RequestContext.authenticated_user`. Removed the racy `get_authenticated_user(transport)`.
- **ctx-aware tool handlers**: opt-in `handler(args, ctx)` via `applicable` (plain `handler(args)` still works).
- **Fail-closed validators**: explicit validator required (no unsafe default); `JWTValidator` rejects `alg=none`, requires a valid `exp`, enforces `iss`/`aud` when configured; `IntrospectionValidator` binds `iss`/`aud`/`exp`; `GitHubOAuthValidator` requires org `state == "active"`; generic auth-error responses (no token/policy oracle).

## ⚠️ Security note / deferred

`JWTValidator` validates **claims only — no signature verification** (documented; `alg=none` rejected). Use `IntrospectionValidator`/`GitHubOAuthValidator` for external issuers. Deferred follow-ups: JWKS signature verification, SSE session-principal binding + stream expiry, per-tool scope enforcement, case-insensitive allowlists, and the OAuth 2.1 Authorization Server.

## Tests

Full suite green — **487 passed** (in-process incl. new JWT fail-closed, required-validator, and per-request/ctx-aware identity tests; existing HTTP/transport tests unchanged). No version bump — part of 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
