### PR TITLE
Add tool `annotations` field to `MCPTool`

### DIFF
--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -670,6 +670,7 @@ function handle_list_tools(ctx::RequestContext, params::ListToolsParams)::Handle
             )
             !isnothing(tool.title) && (d["title"] = tool.title)
             !isnothing(tool.icons) && (d["icons"] = [icon_to_dict(i) for i in tool.icons])
+            !isnothing(tool.annotations) && (d["annotations"] = tool.annotations)
             d
         end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -324,6 +324,9 @@ Implement a tool that can be invoked by clients in the MCP protocol.
 - `input_schema::Union{Nothing,AbstractDict}`: Raw JSON Schema for complex parameter types
 - `handler::Function`: Function that implements the tool's functionality
 - `return_type::Type`: Expected return type of the handler (defaults to Vector{Content})
+- `annotations::Union{Nothing,Dict{String,Any}}`: Optional tool annotations (behavioral
+  hints for clients), e.g. `Dict("readOnlyHint" => true, "destructiveHint" => false,
+  "idempotentHint" => true, "openWorldHint" => false). Emitted verbatim in `tools/list`.
 
 # Parameter Definition
 Tools can define parameters in two ways:
@@ -356,6 +359,7 @@ Base.@kwdef struct MCPTool <: Tool
     return_type::Type = Vector{Content}  # Can be Content subtype or Vector{<:Content}
     title::Union{String,Nothing} = nothing
     icons::Union{Vector{MCPIcon},Nothing} = nothing
+    annotations::Union{Nothing,Dict{String,Any}} = nothing
 end
 
 #==============================================================================

--- a/test/protocol/handlers.jl
+++ b/test/protocol/handlers.jl
@@ -87,6 +87,29 @@ end
         @test !haskey(tool_dict["icons"][1], "mimeType")
     end
 
+    @testset "Tools list includes annotations" begin
+        tool = MCPTool(
+            name="annotated_tool",
+            description="A tool with annotations",
+            parameters=[],
+            handler=(args) -> TextContent(text="ok"),
+            annotations=Dict{String,Any}(
+                "readOnlyHint" => true,
+                "destructiveHint" => false,
+                "idempotentHint" => true,
+                "openWorldHint" => false,
+            )
+        )
+        server = mcp_server(name="test", version="1.0.0", tools=[tool])
+        ctx = RequestContext(server=server, request_id=1)
+        result = ModelContextProtocol.handle_list_tools(ctx, ModelContextProtocol.ListToolsParams())
+        tool_dict = result.response.result["tools"][1]
+        @test tool_dict["annotations"]["readOnlyHint"] == true
+        @test tool_dict["annotations"]["destructiveHint"] == false
+        @test tool_dict["annotations"]["idempotentHint"] == true
+        @test tool_dict["annotations"]["openWorldHint"] == false
+    end
+
     @testset "Prompts list includes title and icons" begin
         icon = MCPIcon(src="data:image/png;base64,abc", sizes=["48x48"])
         prompt = MCPPrompt(
@@ -140,6 +163,7 @@ end
         tool_dict = result.response.result["tools"][1]
         @test !haskey(tool_dict, "title")
         @test !haskey(tool_dict, "icons")
+        @test !haskey(tool_dict, "annotations")
     end
 
     @testset "MCPIcon serialization" begin


### PR DESCRIPTION
MCP tools support an optional `annotations` object carrying behavioral hints (readOnlyHint, destructiveHint, idempotentHint, openWorldHint) that clients can use for trust and approval decisions. `MCPTool` currently does not have a way to express them and `handle_list_tools` does not emit them. Today, you can set `title` and `icons` but not annotations.

Thus, this PR introduces the following:
- MCPTool: add `annotations::Union{Nothing,Dict{String,Any}} = nothing`.
- handle_list_tools: emit `annotations` when set (alongside title/icons).
- tests in `test/protocol/handlers.jl`: annotations show up in the `tools/list` entry, and are omitted when unset