### PR TITLE
Add structured tool output (output_schema + structuredContent)

### DIFF
--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -670,6 +670,7 @@ function handle_list_tools(ctx::RequestContext, params::ListToolsParams)::Handle
             )
             !isnothing(tool.title) && (d["title"] = tool.title)
             !isnothing(tool.icons) && (d["icons"] = [icon_to_dict(i) for i in tool.icons])
+            !isnothing(tool.annotations) && (d["annotations"] = tool.annotations)
             d
         end
 

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -671,6 +671,7 @@ function handle_list_tools(ctx::RequestContext, params::ListToolsParams)::Handle
             !isnothing(tool.title) && (d["title"] = tool.title)
             !isnothing(tool.icons) && (d["icons"] = [icon_to_dict(i) for i in tool.icons])
             !isnothing(tool.annotations) && (d["annotations"] = tool.annotations)
+            !isnothing(tool.output_schema) && (d["outputSchema"] = tool.output_schema)
             d
         end
 

--- a/src/protocol/messages.jl
+++ b/src/protocol/messages.jl
@@ -178,17 +178,22 @@ Base.@kwdef struct CallToolParams <: RequestParams
 end
 
 """
-    CallToolResult(; content::Vector{Dict{String,Any}}, is_error::Bool=false) <: ResponseResult
+    CallToolResult(; content::Vector{Dict{String,Any}}, is_error::Bool=false,
+                   structured_content=nothing) <: ResponseResult
 
 Result returned from a tool invocation.
 
 # Fields
 - `content::Vector{Dict{String,Any}}`: Content produced by the tool
 - `is_error::Bool`: Whether the tool execution resulted in an error
+- `structured_content::Union{Nothing,Any}`: Optional structured result, serialized as
+  `structuredContent` in the response and omitted when `nothing`. Pair it with the
+  tool's `output_schema` so clients can validate and consume the data programmatically.
 """
 Base.@kwdef struct CallToolResult <: ResponseResult
     content::Vector{Dict{String,Any}}
     is_error::Bool = false
+    structured_content::Union{Nothing,Any} = nothing
 end
 
 #= Prompt-Related Messages =#

--- a/src/types.jl
+++ b/src/types.jl
@@ -324,6 +324,9 @@ Implement a tool that can be invoked by clients in the MCP protocol.
 - `input_schema::Union{Nothing,AbstractDict}`: Raw JSON Schema for complex parameter types
 - `handler::Function`: Function that implements the tool's functionality
 - `return_type::Type`: Expected return type of the handler (defaults to Vector{Content})
+- `annotations::Union{Nothing,Dict{String,Any}}`: Optional tool annotations (behavioral
+  hints for clients), e.g. `Dict("readOnlyHint" => true, "destructiveHint" => false,
+  "idempotentHint" => true, "openWorldHint" => false). Emitted verbatim in `tools/list`.
 
 # Parameter Definition
 Tools can define parameters in two ways:
@@ -356,6 +359,7 @@ Base.@kwdef struct MCPTool <: Tool
     return_type::Type = Vector{Content}  # Can be Content subtype or Vector{<:Content}
     title::Union{String,Nothing} = nothing
     icons::Union{Vector{MCPIcon},Nothing} = nothing
+    annotations::Union{Nothing,Dict{String,Any}} = nothing
 end
 
 #==============================================================================

--- a/src/types.jl
+++ b/src/types.jl
@@ -327,6 +327,9 @@ Implement a tool that can be invoked by clients in the MCP protocol.
 - `annotations::Union{Nothing,Dict{String,Any}}`: Optional tool annotations (behavioral
   hints for clients), e.g. `Dict("readOnlyHint" => true, "destructiveHint" => false,
   "idempotentHint" => true, "openWorldHint" => false). Emitted verbatim in `tools/list`.
+- `output_schema::Union{Nothing,AbstractDict}`: Optional JSON Schema for the tool's
+  structured result, emitted as `outputSchema` in `tools/list`. Pair it with a
+  `CallToolResult(structured_content=…)` so clients can validate the structured output.
 
 # Parameter Definition
 Tools can define parameters in two ways:
@@ -360,6 +363,7 @@ Base.@kwdef struct MCPTool <: Tool
     title::Union{String,Nothing} = nothing
     icons::Union{Vector{MCPIcon},Nothing} = nothing
     annotations::Union{Nothing,Dict{String,Any}} = nothing
+    output_schema::Union{Nothing,AbstractDict} = nothing
 end
 
 #==============================================================================

--- a/src/utils/serialization.jl
+++ b/src/utils/serialization.jl
@@ -56,6 +56,22 @@ function StructTypes.omitempties(::Type{ListPromptsResult})
 end
 
 """
+    StructTypes.names(::Type{CallToolResult})
+
+Map the Julia field `structured_content` to the protocol key `structuredContent`.
+(The other fields keep their names; unlisted fields are unaffected.)
+"""
+StructTypes.names(::Type{CallToolResult}) = ((:structured_content, :structuredContent),)
+
+"""
+    StructTypes.omitempties(::Type{CallToolResult}) -> Tuple{Symbol}
+
+Omit `structured_content` from the response when it is `nothing`, so tools that
+don't produce structured output emit no `structuredContent` key.
+"""
+StructTypes.omitempties(::Type{CallToolResult}) = (:structured_content,)
+
+"""
     content2dict(content::Content) -> Dict{String,Any}
 
 Convert a Content object to its dictionary representation for JSON serialization.

--- a/test/protocol/handlers.jl
+++ b/test/protocol/handlers.jl
@@ -110,6 +110,26 @@ end
         @test tool_dict["annotations"]["openWorldHint"] == false
     end
 
+    @testset "Tools list includes outputSchema" begin
+        schema = Dict{String,Any}(
+            "type" => "object",
+            "properties" => Dict{String,Any}("answer" => Dict{String,Any}("type" => "integer")),
+        )
+        tool = MCPTool(
+            name="schema_tool",
+            description="A tool with an output schema",
+            parameters=[],
+            handler=(args) -> TextContent(text="ok"),
+            output_schema=schema,
+        )
+        server = mcp_server(name="test", version="1.0.0", tools=[tool])
+        ctx = RequestContext(server=server, request_id=1)
+        result = ModelContextProtocol.handle_list_tools(ctx, ModelContextProtocol.ListToolsParams())
+        tool_dict = result.response.result["tools"][1]
+        @test tool_dict["outputSchema"]["type"] == "object"
+        @test haskey(tool_dict["outputSchema"]["properties"], "answer")
+    end
+
     @testset "Prompts list includes title and icons" begin
         icon = MCPIcon(src="data:image/png;base64,abc", sizes=["48x48"])
         prompt = MCPPrompt(
@@ -164,6 +184,7 @@ end
         @test !haskey(tool_dict, "title")
         @test !haskey(tool_dict, "icons")
         @test !haskey(tool_dict, "annotations")
+        @test !haskey(tool_dict, "outputSchema")
     end
 
     @testset "MCPIcon serialization" begin

--- a/test/protocol/handlers.jl
+++ b/test/protocol/handlers.jl
@@ -87,6 +87,29 @@ end
         @test !haskey(tool_dict["icons"][1], "mimeType")
     end
 
+    @testset "Tools list includes annotations" begin
+        tool = MCPTool(
+            name="annotated_tool",
+            description="A tool with annotations",
+            parameters=[],
+            handler=(args) -> TextContent(text="ok"),
+            annotations=Dict{String,Any}(
+                "readOnlyHint" => true,
+                "destructiveHint" => false,
+                "idempotentHint" => true,
+                "openWorldHint" => false,
+            )
+        )
+        server = mcp_server(name="test", version="1.0.0", tools=[tool])
+        ctx = RequestContext(server=server, request_id=1)
+        result = ModelContextProtocol.handle_list_tools(ctx, ModelContextProtocol.ListToolsParams())
+        tool_dict = result.response.result["tools"][1]
+        @test tool_dict["annotations"]["readOnlyHint"] == true
+        @test tool_dict["annotations"]["destructiveHint"] == false
+        @test tool_dict["annotations"]["idempotentHint"] == true
+        @test tool_dict["annotations"]["openWorldHint"] == false
+    end
+
     @testset "Prompts list includes title and icons" begin
         icon = MCPIcon(src="data:image/png;base64,abc", sizes=["48x48"])
         prompt = MCPPrompt(
@@ -140,6 +163,7 @@ end
         tool_dict = result.response.result["tools"][1]
         @test !haskey(tool_dict, "title")
         @test !haskey(tool_dict, "icons")
+        @test !haskey(tool_dict, "annotations")
     end
 
     @testset "MCPIcon serialization" begin

--- a/test/utils/serialization.jl
+++ b/test/utils/serialization.jl
@@ -124,3 +124,22 @@
         end
     end
 end
+
+@testset "CallToolResult structuredContent serialization" begin
+    with_sc = CallToolResult(
+        content = [Dict{String,Any}("type" => "text", "text" => "hi")],
+        structured_content = Dict("answer" => 42),
+    )
+    without_sc = CallToolResult(
+        content = [Dict{String,Any}("type" => "text", "text" => "hi")],
+    )
+    j_with = JSON3.read(JSON3.write(with_sc), Dict{String,Any})
+    j_without = JSON3.read(JSON3.write(without_sc), Dict{String,Any})
+
+    # structured_content is emitted as `structuredContent`, omitted when nothing
+    @test j_with["structuredContent"]["answer"] == 42
+    @test !haskey(j_without, "structuredContent")
+    # existing fields are unaffected
+    @test haskey(j_with, "content")
+    @test j_with["is_error"] == false
+end


### PR DESCRIPTION
Depends on #44 

A tool can declare an `outputSchema` and return `structuredContent`. This enables clients to get machine readable results instead of parsing text out of the content blocks. Neither is modeled today in ModelContextProtocol.jl.

Thus, this PR introduces the following:
 - add `output_schema::Union{Nothing,AbstractDict} = nothing` to `MCPTool`; emit as `outputSchema` in `handle_list_tools`
 - add `structured_content::Union{Nothing,Any} = nothing` to `CallToolResult`; serialize as `structuredContent`, omitted when `nothing` (via `StructTypes` names/omitempties). `handle_call_tool` already returns `CallToolResult`.
 - tests: `outputSchema` in `tools/list` (omitted when unset); `structuredContent` is also handled gracefully by being omitted when `nothing`