### PR TITLE
Add progress notifications for tool handlers

### DIFF
--- a/src/ModelContextProtocol.jl
+++ b/src/ModelContextProtocol.jl
@@ -112,6 +112,7 @@ export
     
     # Advanced features
     Server,  # For type annotations in user code
+    RequestContext, send_progress,  # Progress reporting from tool handlers
     subscribe!, unsubscribe!,  # Resource subscription management
     content2dict,  # Utility for debugging/testing
 

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -28,6 +28,38 @@ Base.@kwdef mutable struct RequestContext
 end
 
 """
+    send_progress(ctx::RequestContext, progress::Real;
+                  total::Union{Real,Nothing}=nothing,
+                  message::Union{String,Nothing}=nothing) -> Bool
+
+Emit an MCP `notifications/progress` for the current request. A tool handler that
+accepts the `RequestContext` (its second argument) can call this during a long
+operation to report progress.
+
+Returns `false` (a no-op) when the client did not supply a `progressToken` or no
+transport is connected, so it is always safe to call. Send an increasing
+`progress`; include `total` for a determinate bar and `message` for a status line.
+"""
+function send_progress(ctx::RequestContext, progress::Real;
+                       total::Union{Real,Nothing}=nothing,
+                       message::Union{String,Nothing}=nothing)::Bool
+    (ctx.progress_token === nothing || ctx.server.transport === nothing) && return false
+    params = Dict{String,Any}(
+        "progressToken" => ctx.progress_token,
+        "progress" => Float64(progress),
+    )
+    total !== nothing && (params["total"] = Float64(total))
+    message !== nothing && (params["message"] = message)
+    try
+        write_message(ctx.server.transport,
+                      serialize_message(JSONRPCNotification(method="notifications/progress", params=params)))
+        return true
+    catch
+        return false
+    end
+end
+
+"""
     HandlerResult(; response::Union{Response,Nothing}=nothing, 
                 error::Union{ErrorInfo,Nothing}=nothing)
 
@@ -549,8 +581,11 @@ function handle_call_tool(ctx::RequestContext, params::CallToolParams)::HandlerR
             end
         end
         
-        # Call the tool handler with the arguments
-        result = tool.handler(args)
+        # Call the tool handler. Handlers that opt in by accepting a second argument
+        # receive the RequestContext (for progress reporting via send_progress, the
+        # request id, etc.); one-argument handlers are called as before. Backward
+        # compatible — existing tools are untouched.
+        result = applicable(tool.handler, args, ctx) ? tool.handler(args, ctx) : tool.handler(args)
         
         # Check if the handler returned a complete CallToolResult
         if result isa CallToolResult

--- a/src/protocol/jsonrpc.jl
+++ b/src/protocol/jsonrpc.jl
@@ -158,11 +158,22 @@ function parse_request(raw::JSON3.Object)::Request
     else
         nothing
     end
-    
+
+    # Extract the optional progress token from params._meta.progressToken so a
+    # handler can report progress for this request (see RequestContext / send_progress).
+    progress_token = nothing
+    if haskey(raw, :params) && !isempty(raw.params) && haskey(raw.params, :_meta)
+        meta = raw.params._meta
+        if haskey(meta, :progressToken)
+            progress_token = meta.progressToken
+        end
+    end
+
     JSONRPCRequest(
         id = raw.id,
         method = method,
-        params = typed_params
+        params = typed_params,
+        meta = RequestMeta(progress_token = progress_token)
     )
 end
 

--- a/test/protocol/handlers.jl
+++ b/test/protocol/handlers.jl
@@ -254,3 +254,92 @@ end
         @test server_info["icons"][3]["sizes"] == ["any"]
     end
 end
+
+@testset "Progress notifications" begin
+    @testset "send_progress is a no-op without a token" begin
+        server = mcp_server(name="test", version="1.0.0")
+        ctx = RequestContext(server=server)  # no progress_token, no transport
+        @test send_progress(ctx, 1) == false
+    end
+
+    @testset "send_progress is a no-op without a transport" begin
+        server = mcp_server(name="test", version="1.0.0")  # transport defaults to nothing
+        ctx = RequestContext(server=server, progress_token="tok")
+        @test send_progress(ctx, 1) == false
+    end
+
+    @testset "send_progress writes a notifications/progress message" begin
+        server = mcp_server(name="test", version="1.0.0")
+        buf = IOBuffer()
+        server.transport = StdioTransport(output=buf)
+        ctx = RequestContext(server=server, progress_token="tok-1")
+
+        @test send_progress(ctx, 3; total=10, message="working") == true
+
+        notif = JSON3.read(String(take!(buf)))
+        @test notif["jsonrpc"] == "2.0"
+        @test notif["method"] == "notifications/progress"
+        @test notif["params"]["progressToken"] == "tok-1"
+        @test notif["params"]["progress"] == 3.0
+        @test notif["params"]["total"] == 10.0
+        @test notif["params"]["message"] == "working"
+    end
+
+    @testset "send_progress omits total/message when not given" begin
+        server = mcp_server(name="test", version="1.0.0")
+        buf = IOBuffer()
+        server.transport = StdioTransport(output=buf)
+        ctx = RequestContext(server=server, progress_token=7)  # integer token
+
+        @test send_progress(ctx, 1.5) == true
+
+        notif = JSON3.read(String(take!(buf)))
+        @test notif["params"]["progressToken"] == 7
+        @test notif["params"]["progress"] == 1.5
+        @test !haskey(notif["params"], "total")
+        @test !haskey(notif["params"], "message")
+    end
+
+    @testset "handle_call_tool passes the context to a two-argument handler" begin
+        tool = MCPTool(
+            name="ctx_tool",
+            description="Echoes the progress token from its context",
+            parameters=[],
+            handler=(args, ctx) -> TextContent(text=string(ctx.progress_token))
+        )
+        server = mcp_server(name="test", version="1.0.0", tools=[tool])
+        ctx = RequestContext(server=server, request_id=1, progress_token="abc")
+        result = handle_call_tool(ctx, CallToolParams(name="ctx_tool"))
+        @test result.response.result.content[1]["text"] == "abc"
+    end
+
+    @testset "handle_call_tool still calls one-argument handlers" begin
+        tool = MCPTool(
+            name="plain_handler",
+            description="Ignores any context",
+            parameters=[],
+            handler=(args) -> TextContent(text="one-arg")
+        )
+        server = mcp_server(name="test", version="1.0.0", tools=[tool])
+        ctx = RequestContext(server=server, request_id=1, progress_token="ignored")
+        result = handle_call_tool(ctx, CallToolParams(name="plain_handler"))
+        @test result.response.result.content[1]["text"] == "one-arg"
+    end
+
+    @testset "parse_request extracts params._meta.progressToken" begin
+        raw = """
+        {"jsonrpc":"2.0","id":1,"method":"tools/call",
+         "params":{"name":"x","arguments":{},"_meta":{"progressToken":"pt-9"}}}
+        """
+        req = ModelContextProtocol.parse_message(raw)
+        @test req isa JSONRPCRequest
+        @test req.meta.progress_token == "pt-9"
+    end
+
+    @testset "parse_request leaves progress token nothing when absent" begin
+        raw = """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"x","arguments":{}}}"""
+        req = ModelContextProtocol.parse_message(raw)
+        @test req isa JSONRPCRequest
+        @test req.meta.progress_token === nothing
+    end
+end


### PR DESCRIPTION
Tool handlers cannot, in their current form, report progress during long operations. They only receive their arguments, with no access to the request's progress token or the server transport. Without this, they have no way to emit notifications or progress information for downstream applications. This PR adds this capability.

 - `handle_call_tool` passes the `RequestContext` to handlers that accept a second argument; handlers with a single argument are called as before, avoiding any regressions. 
  - `send_progress(ctx, progress; total=nothing, message=nothing)` writes a `notifications/progress`. It's a no-op when the client sends no `progressToken` or no transport is connected, so it's always safe to call.
  - `parse_request` now extracts `params._meta.progressToken` into `RequestMeta`. Previously, this was dropped, so `handle_request` (which already threads the token into the context) never saw it and progress could
  never fire.
  - Exports `RequestContext` and `send_progress`.

  A handler can opt in to sharing progress by accepting `(args, ctx)`. For example:

  ```julia
  handler = (args, ctx) -> begin
      for (i, s) in enumerate(steps)
          send_progress(ctx, i; total=length(steps), message="step $i")
          work(s)
      end
      TextContent(text="done")
  end
  ```

I apologize in advance if the tests are excessive. They seek to cover each of the above items.