### PR TITLE
fix: CallToolResult emits spec `isError`; structuredContent typed as object

### DIFF
--- a/src/protocol/messages.jl
+++ b/src/protocol/messages.jl
@@ -186,14 +186,14 @@ Result returned from a tool invocation.
 # Fields
 - `content::Vector{Dict{String,Any}}`: Content produced by the tool
 - `is_error::Bool`: Whether the tool execution resulted in an error
-- `structured_content::Union{Nothing,Any}`: Optional structured result, serialized as
-  `structuredContent` in the response and omitted when `nothing`. Pair it with the
-  tool's `output_schema` so clients can validate and consume the data programmatically.
+- `structured_content::Union{Nothing,AbstractDict}`: Optional structured result (a JSON
+  object per the MCP spec), serialized as `structuredContent` and omitted when `nothing`.
+  Pair it with the tool's `output_schema` so clients can validate and consume it programmatically.
 """
 Base.@kwdef struct CallToolResult <: ResponseResult
     content::Vector{Dict{String,Any}}
     is_error::Bool = false
-    structured_content::Union{Nothing,Any} = nothing
+    structured_content::Union{Nothing,AbstractDict} = nothing
 end
 
 #= Prompt-Related Messages =#

--- a/src/utils/serialization.jl
+++ b/src/utils/serialization.jl
@@ -58,10 +58,10 @@ end
 """
     StructTypes.names(::Type{CallToolResult})
 
-Map the Julia field `structured_content` to the protocol key `structuredContent`.
-(The other fields keep their names; unlisted fields are unaffected.)
+Map Julia field names to their MCP wire keys: `is_error` → `isError` (the spec key —
+clients rely on it to detect tool errors) and `structured_content` → `structuredContent`.
 """
-StructTypes.names(::Type{CallToolResult}) = ((:structured_content, :structuredContent),)
+StructTypes.names(::Type{CallToolResult}) = ((:is_error, :isError), (:structured_content, :structuredContent))
 
 """
     StructTypes.omitempties(::Type{CallToolResult}) -> Tuple{Symbol}

--- a/test/transports/test_http.jl
+++ b/test/transports/test_http.jl
@@ -174,7 +174,7 @@
         result = JSON3.read(String(response.body))
         @test result["id"] == 2
         @test result["result"]["content"][1]["text"] == "Echo: Hello MCP"
-        @test result["result"]["is_error"] == false
+        @test result["result"]["isError"] == false
         
         # Clean up
         server.active = false

--- a/test/utils/serialization.jl
+++ b/test/utils/serialization.jl
@@ -141,5 +141,5 @@ end
     @test !haskey(j_without, "structuredContent")
     # existing fields are unaffected
     @test haskey(j_with, "content")
-    @test j_with["is_error"] == false
+    @test j_with["isError"] == false  # is_error -> isError wire key
 end


### PR DESCRIPTION
Fast-follow polish on the merged structured-output PR (#45), from the Codex review of the samtalki PRs.

## Changes
- **`is_error` → `isError` wire key** (the important one): `CallToolResult` now serializes its error flag under the MCP spec key `isError` (added to `StructTypes.names`). Spec-compliant clients read `isError` to detect tool failures — so until now **every tool error looked like a success** to them. Julia field stays `is_error`; only the wire key changes.
- **`structured_content` typed `Union{Nothing,AbstractDict}`** (was effectively `Any`). MCP `structuredContent` is a JSON object; this rejects root scalars/arrays and non-serializable values at construction time.
- Updated the two tests that asserted the serialized `is_error` key (`test_http`, `serialization`).

Suite green (**499**). No version bump — part of the unreleased 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
