### PR TITLE
feat: progress notifications for tool handlers (from #46, HTTP-correct)

### DIFF
--- a/src/ModelContextProtocol.jl
+++ b/src/ModelContextProtocol.jl
@@ -115,6 +115,7 @@ export
     
     # Advanced features
     Server,  # For type annotations in user code
+    RequestContext, send_progress,  # Progress reporting from tool handlers
     subscribe!, unsubscribe!,  # Resource subscription management
     content2dict,  # Utility for debugging/testing
 

--- a/src/ModelContextProtocol.jl
+++ b/src/ModelContextProtocol.jl
@@ -115,7 +115,7 @@ export
     
     # Advanced features
     Server,  # For type annotations in user code
-    RequestContext, send_progress,  # Progress reporting from tool handlers
+    send_progress,  # Progress reporting from tool handlers (RequestContext is intentionally not exported)
     subscribe!, unsubscribe!,  # Resource subscription management
     content2dict,  # Utility for debugging/testing
 

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -29,6 +29,38 @@ Base.@kwdef mutable struct RequestContext
 end
 
 """
+    send_progress(ctx::RequestContext, progress::Real;
+                  total::Union{Real,Nothing}=nothing,
+                  message::Union{String,Nothing}=nothing) -> Bool
+
+Emit an MCP `notifications/progress` for the current request. A tool handler that
+accepts the `RequestContext` (its second argument) can call this during a long
+operation to report progress.
+
+Returns `false` (a no-op) when the client did not supply a `progressToken` or no
+transport is connected, so it is always safe to call. Send an increasing
+`progress`; include `total` for a determinate bar and `message` for a status line.
+"""
+function send_progress(ctx::RequestContext, progress::Real;
+                       total::Union{Real,Nothing}=nothing,
+                       message::Union{String,Nothing}=nothing)::Bool
+    (ctx.progress_token === nothing || ctx.server.transport === nothing) && return false
+    params = Dict{String,Any}(
+        "progressToken" => ctx.progress_token,
+        "progress" => Float64(progress),
+    )
+    total !== nothing && (params["total"] = Float64(total))
+    message !== nothing && (params["message"] = message)
+    try
+        write_message(ctx.server.transport,
+                      serialize_message(JSONRPCNotification(method="notifications/progress", params=params)))
+        return true
+    catch
+        return false
+    end
+end
+
+"""
     HandlerResult(; response::Union{Response,Nothing}=nothing, 
                 error::Union{ErrorInfo,Nothing}=nothing)
 
@@ -551,8 +583,9 @@ function handle_call_tool(ctx::RequestContext, params::CallToolParams)::HandlerR
         end
         
         # Call the tool handler. Handlers may opt into a context-aware form
-        # `handler(args, ctx)` to access `ctx.authenticated_user` etc.; the plain
-        # `handler(args)` form keeps working. Dispatch by applicability (not by
+        # `handler(args, ctx)` to access the RequestContext — `ctx.authenticated_user`,
+        # progress reporting via `send_progress(ctx, ...)`, the request id, etc.; the
+        # plain `handler(args)` form keeps working. Dispatch by applicability (not by
         # catching MethodError, which would mask errors thrown inside a handler).
         result = applicable(tool.handler, args, ctx) ? tool.handler(args, ctx) : tool.handler(args)
         

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -52,8 +52,10 @@ function send_progress(ctx::RequestContext, progress::Real;
     total !== nothing && (params["total"] = Float64(total))
     message !== nothing && (params["message"] = message)
     try
-        write_message(ctx.server.transport,
-                      serialize_message(JSONRPCNotification(method="notifications/progress", params=params)))
+        send_notification(
+            ctx.server.transport,
+            serialize_message(JSONRPCNotification(method="notifications/progress", params=params)),
+        )
         return true
     catch
         return false

--- a/src/protocol/jsonrpc.jl
+++ b/src/protocol/jsonrpc.jl
@@ -158,11 +158,22 @@ function parse_request(raw::JSON3.Object)::Request
     else
         nothing
     end
-    
+
+    # Extract the optional progress token from params._meta.progressToken so a
+    # handler can report progress for this request (see RequestContext / send_progress).
+    progress_token = nothing
+    if haskey(raw, :params) && !isempty(raw.params) && haskey(raw.params, :_meta)
+        meta = raw.params._meta
+        if haskey(meta, :progressToken)
+            progress_token = meta.progressToken
+        end
+    end
+
     JSONRPCRequest(
         id = raw.id,
         method = method,
-        params = typed_params
+        params = typed_params,
+        meta = RequestMeta(progress_token = progress_token)
     )
 end
 

--- a/src/transports/base.jl
+++ b/src/transports/base.jl
@@ -63,6 +63,26 @@ Write a message to the transport.
 function write_message end
 
 """
+    send_notification(transport::Transport, message::String) -> Nothing
+
+Deliver a server-to-client JSON-RPC notification over `transport`.
+
+The default writes the message directly — correct for stdio, where notifications and
+responses share one stream. Transports that multiplex per-request responses (e.g. HTTP,
+where `write_message` routes to the *calling request's* response channel) override this to
+send notifications over a separate out-of-band channel, so a mid-request notification
+never corrupts that request's response.
+
+# Arguments
+- `transport::Transport`: The transport instance to send over
+- `message::String`: The serialized JSON-RPC notification
+
+# Returns
+- `Nothing`
+"""
+send_notification(transport::Transport, message::String) = write_message(transport, message)
+
+"""
     close(transport::Transport) -> Nothing
 
 Close the transport connection and clean up resources.

--- a/test/protocol/handlers.jl
+++ b/test/protocol/handlers.jl
@@ -299,3 +299,92 @@ end
         @test server_info["icons"][3]["sizes"] == ["any"]
     end
 end
+
+@testset "Progress notifications" begin
+    @testset "send_progress is a no-op without a token" begin
+        server = mcp_server(name="test", version="1.0.0")
+        ctx = RequestContext(server=server)  # no progress_token, no transport
+        @test send_progress(ctx, 1) == false
+    end
+
+    @testset "send_progress is a no-op without a transport" begin
+        server = mcp_server(name="test", version="1.0.0")  # transport defaults to nothing
+        ctx = RequestContext(server=server, progress_token="tok")
+        @test send_progress(ctx, 1) == false
+    end
+
+    @testset "send_progress writes a notifications/progress message" begin
+        server = mcp_server(name="test", version="1.0.0")
+        buf = IOBuffer()
+        server.transport = StdioTransport(output=buf)
+        ctx = RequestContext(server=server, progress_token="tok-1")
+
+        @test send_progress(ctx, 3; total=10, message="working") == true
+
+        notif = JSON3.read(String(take!(buf)))
+        @test notif["jsonrpc"] == "2.0"
+        @test notif["method"] == "notifications/progress"
+        @test notif["params"]["progressToken"] == "tok-1"
+        @test notif["params"]["progress"] == 3.0
+        @test notif["params"]["total"] == 10.0
+        @test notif["params"]["message"] == "working"
+    end
+
+    @testset "send_progress omits total/message when not given" begin
+        server = mcp_server(name="test", version="1.0.0")
+        buf = IOBuffer()
+        server.transport = StdioTransport(output=buf)
+        ctx = RequestContext(server=server, progress_token=7)  # integer token
+
+        @test send_progress(ctx, 1.5) == true
+
+        notif = JSON3.read(String(take!(buf)))
+        @test notif["params"]["progressToken"] == 7
+        @test notif["params"]["progress"] == 1.5
+        @test !haskey(notif["params"], "total")
+        @test !haskey(notif["params"], "message")
+    end
+
+    @testset "handle_call_tool passes the context to a two-argument handler" begin
+        tool = MCPTool(
+            name="ctx_tool",
+            description="Echoes the progress token from its context",
+            parameters=[],
+            handler=(args, ctx) -> TextContent(text=string(ctx.progress_token))
+        )
+        server = mcp_server(name="test", version="1.0.0", tools=[tool])
+        ctx = RequestContext(server=server, request_id=1, progress_token="abc")
+        result = handle_call_tool(ctx, CallToolParams(name="ctx_tool"))
+        @test result.response.result.content[1]["text"] == "abc"
+    end
+
+    @testset "handle_call_tool still calls one-argument handlers" begin
+        tool = MCPTool(
+            name="plain_handler",
+            description="Ignores any context",
+            parameters=[],
+            handler=(args) -> TextContent(text="one-arg")
+        )
+        server = mcp_server(name="test", version="1.0.0", tools=[tool])
+        ctx = RequestContext(server=server, request_id=1, progress_token="ignored")
+        result = handle_call_tool(ctx, CallToolParams(name="plain_handler"))
+        @test result.response.result.content[1]["text"] == "one-arg"
+    end
+
+    @testset "parse_request extracts params._meta.progressToken" begin
+        raw = """
+        {"jsonrpc":"2.0","id":1,"method":"tools/call",
+         "params":{"name":"x","arguments":{},"_meta":{"progressToken":"pt-9"}}}
+        """
+        req = ModelContextProtocol.parse_message(raw)
+        @test req isa JSONRPCRequest
+        @test req.meta.progress_token == "pt-9"
+    end
+
+    @testset "parse_request leaves progress token nothing when absent" begin
+        raw = """{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"x","arguments":{}}}"""
+        req = ModelContextProtocol.parse_message(raw)
+        @test req isa JSONRPCRequest
+        @test req.meta.progress_token === nothing
+    end
+end

--- a/test/protocol/handlers.jl
+++ b/test/protocol/handlers.jl
@@ -387,4 +387,24 @@ end
         @test req isa JSONRPCRequest
         @test req.meta.progress_token === nothing
     end
+
+    @testset "send_progress routes to the HTTP notification queue, not the response" begin
+        # On HTTP, write_message delivers to the calling request's response channel, so
+        # routing progress there would be returned as (and corrupt) the response. The
+        # transport-polymorphic send_notification sends it over the SSE queue instead.
+        transport = HttpTransport(port=8099)
+        transport.connected = true  # mark connected without binding a port
+        server = mcp_server(name="test", version="1.0.0")
+        server.transport = transport
+        ctx = RequestContext(server=server, progress_token="http-tok")
+
+        @test send_progress(ctx, 2; total=5) == true
+        @test isready(transport.notification_queue)   # delivered out-of-band (SSE)
+        @test isempty(transport.response_channels)     # response path untouched
+        notif = JSON3.read(take!(transport.notification_queue))
+        @test notif["method"] == "notifications/progress"
+        @test notif["params"]["progressToken"] == "http-tok"
+        @test notif["params"]["progress"] == 2.0
+        @test notif["params"]["total"] == 5.0
+    end
 end


### PR DESCRIPTION
Lands the progress-notifications feature from **#46 by @samtalki** (their commit cherry-picked, authorship preserved), with two take-over fixups from the Codex review. Supersedes #46; closes #33.

## What it adds
A tool handler can opt into `(args, ctx)` and report progress during long work:
```julia
handler = (args, ctx) -> begin
    for i in 1:n
        send_progress(ctx, i; total=n, message="step $i")
        work(i)
    end
    TextContent(text="done")
end
```
- `send_progress(ctx, progress; total, message)` emits `notifications/progress`; a no-op (returns `false`) when the client sent no `progressToken` or no transport is connected, so it's always safe to call.
- `parse_request` now extracts `params._meta.progressToken` into `RequestMeta` — it was being dropped, so `RequestContext.progress_token` never populated. (samtalki's fix.)

## Fixups on top of #46 (Codex review)
- **HTTP-correct delivery.** `send_progress` routes through a transport-polymorphic `send_notification` instead of `write_message`. On HTTP, `write_message` delivers to the *calling request's* response channel — so a mid-request progress notification was returned as (and corrupted) the tool response. `send_notification(::Transport)` defaults to `write_message` (correct for stdio); `HttpTransport` queues to the SSE `notification_queue`, out-of-band from responses. New test asserts progress lands on the notification queue with the response path untouched.
- **`RequestContext` kept internal** (not exported). Handlers receive `ctx` and use `send_progress(ctx, …)` + field access without naming the type, so exporting the concrete mutable struct would lock in its still-evolving shape for no functional gain. Exportable later if users want it (non-breaking).

The redundant `handle_call_tool` ctx-dispatch line from #46 is dropped (already on main via #42).

Suite green (**526**). Part of the unreleased 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
