### PR TITLE
feat: Wave-2 2025-11-25 conformance — AudioContent, ResourceLink spec fix, description, _meta, schema dialect, header echo (0.5.1)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,11 @@
 name: E2E
-# End-to-end protocol tests: spawn the shipped example servers as real
-# subprocesses and drive the MCP handshake as an external client. These are
-# skipped by the regular CI matrix (they pay full JIT startup per server) and
-# run here nightly, plus on demand via the Actions "Run workflow" button.
+# End-to-end protocol tests: spawn the shipped example servers (and the wire-
+# conformance fixture) as real subprocesses and drive them as an external
+# client — full bodies and HTTP headers, the things in-process tests can't
+# see. Skipped by the regular CI matrix (they pay full JIT startup per
+# server); run here on every PR, nightly, and on demand.
 on:
+  pull_request: {}
   schedule:
     - cron: '0 7 * * *'   # nightly at 07:00 UTC
   workflow_dispatch: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AudioContent` — the third media content type (`{"type": "audio", "data": ..., "mimeType": ...}`),
   usable in tool results and prompt messages.
+- `PromptMessage` content accepts the full spec ContentBlock union: `AudioContent` and
+  `ResourceLink` joined `TextContent`/`ImageContent`/`EmbeddedResource`.
+- `ResourceLink` gained the spec's optional `size` field (bytes).
 - `serverInfo.description`: `mcp_server(; description = ...)` is now emitted in the initialize
   response (MCP 2025-11-25). The `Implementation` type (clientInfo) gained optional
   `title`/`description` fields.
@@ -34,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The HTTP `MCP-Protocol-Version` **response header now echoes the negotiated version** after
   `initialize` (previously a static per-transport default, so a client negotiating an older
   version saw a mismatched header). New transport hook: `set_negotiated_version!`.
+- **`prompts/get` now serializes media content in the spec wire format** (base64 `data` +
+  `mimeType`, via `content2dict`) — previously image (and would-be audio) prompt messages
+  leaked raw Julia struct fields (`mime_type`, integer byte arrays), which compliant clients
+  could not consume. `prompts/get` results are now plain JSON objects rather than
+  `GetPromptResult` structs.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leaked raw Julia struct fields (`mime_type`, integer byte arrays), which compliant clients
   could not consume. `prompts/get` results are now plain JSON objects rather than
   `GetPromptResult` structs.
+- **`prompts/get` without `arguments` no longer errors.** The no-arguments path passed a
+  `LittleDict` to `process_template`, which was typed `::Dict` and threw a `MethodError`
+  (surfacing to clients as an internal error for any text prompt fetched argument-free).
+  Found by live-server testing; affected 0.5.0 and earlier.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-09
+
+### Added
+
+- `AudioContent` — the third media content type (`{"type": "audio", "data": ..., "mimeType": ...}`),
+  usable in tool results and prompt messages.
+- `serverInfo.description`: `mcp_server(; description = ...)` is now emitted in the initialize
+  response (MCP 2025-11-25). The `Implementation` type (clientInfo) gained optional
+  `title`/`description` fields.
+- `_meta` on component definitions — `MCPTool`, `MCPResource`, and `MCPPrompt` accept
+  `_meta::Dict{String,Any}`, emitted verbatim in the corresponding `*/list` entries — and on
+  `CallToolResult` (omitted when unset).
+- Tool input schemas generated from `ToolParameter` lists now declare the JSON Schema
+  **2020-12** dialect via `"$schema"`; a raw `input_schema` still passes through verbatim.
+
+### Fixed
+
+- **`ResourceLink` now serializes to the MCP spec wire format**
+  `{"type": "resource_link", "uri": ..., "name": ..., "description": ..., "mimeType": ...}`.
+  Previously it emitted a non-spec `{"type": "link", "href": ...}` shape that compliant clients
+  ignored, so the type never interoperated. The Julia struct changed accordingly
+  (`href` → `uri`, new required `name`, optional `description`/`mime_type`) — technically a
+  field change, shipped as a patch because the old form was unusable with any compliant client
+  and had no observed usage. Found via AIMicroGraph remote-demo field feedback.
+- The HTTP `MCP-Protocol-Version` **response header now echoes the negotiated version** after
+  `initialize` (previously a static per-transport default, so a client negotiating an older
+  version saw a mismatched header). New transport hook: `set_negotiated_version!`.
+
+### Notes
+
+- Docstring guidance added: a tool returning `structuredContent` SHOULD also include a
+  human-readable serialization in `content` for clients that don't consume structured output.
+
 ## [0.5.0] - 2026-06-09
 
 ### Added
@@ -270,7 +303,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stdio transport
 - Basic protocol compliance
 
-[Unreleased]: https://github.com/JuliaSMLM/ModelContextProtocol.jl/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/JuliaSMLM/ModelContextProtocol.jl/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/JuliaSMLM/ModelContextProtocol.jl/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/JuliaSMLM/ModelContextProtocol.jl/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/JuliaSMLM/ModelContextProtocol.jl/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/JuliaSMLM/ModelContextProtocol.jl/compare/v0.3.1...v0.4.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelContextProtocol"
 uuid = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
 authors = ["klidke@unm.edu"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,9 @@ makedocs(;
         canonical = "https://JuliaSMLM.github.io/ModelContextProtocol.jl",
         edit_link = "main",
         assets = String[],
+        # api.md aggregates every docstring and outgrew Documenter's default
+        # 200 KiB per-page limit; it is a reference page, so exempt it
+        size_threshold_ignore = ["api.md"],
     ),
     pages = [
         "Home" => "index.md",

--- a/src/ModelContextProtocol.jl
+++ b/src/ModelContextProtocol.jl
@@ -103,7 +103,7 @@ export
     
     # Content types for tool/resource responses
     Content, ResourceContents,  # Abstract types for type annotations
-    TextContent, ImageContent,
+    TextContent, ImageContent, AudioContent,
     TextResourceContents, BlobResourceContents,
     EmbeddedResource, ResourceLink,
     CallToolResult,  # For explicit error handling in tools

--- a/src/core/server.jl
+++ b/src/core/server.jl
@@ -160,7 +160,11 @@ function run_server_loop(server::Server, state::ServerState)
             # Process the message
             @debug "Processing message" raw=message
             response = process_message(server, state, message; authenticated_user=pending_auth_context(transport))
-            
+
+            # Keep the transport's advertised version in sync with the negotiated one
+            # (set by handle_initialize) so e.g. HTTP response headers echo it
+            isnothing(state.protocol_version) || set_negotiated_version!(transport, state.protocol_version)
+
             if !isnothing(response)
                 @debug "Sending response" response=response
                 write_message(transport, response)

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -397,10 +397,16 @@ function handle_get_prompt(ctx::RequestContext, params::GetPromptParams)::Handle
             end
         end
 
-        # Create proper GetPromptResult
-        result = GetPromptResult(
-            description = prompt.description,
-            messages = processed_messages
+        # Serialize messages through content2dict so media content uses the spec
+        # wire format (base64 `data`, `mimeType`) rather than raw struct fields
+        result = LittleDict{String,Any}(
+            "description" => prompt.description,
+            "messages" => [
+                LittleDict{String,Any}(
+                    "role" => string(msg.role),
+                    "content" => content2dict(msg.content)
+                ) for msg in processed_messages
+            ]
         )
 
         HandlerResult(

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -183,6 +183,7 @@ function handle_initialize(ctx::RequestContext, params::InitializeParams)::Handl
         "name" => ctx.server.config.name,
         "version" => ctx.server.config.version
     )
+    !isempty(ctx.server.config.description) && (server_info["description"] = ctx.server.config.description)
     !isnothing(ctx.server.config.title) && (server_info["title"] = ctx.server.config.title)
     !isnothing(ctx.server.config.icons) && (server_info["icons"] = [icon_to_dict(i) for i in ctx.server.config.icons])
 
@@ -254,6 +255,7 @@ function handle_list_prompts(ctx::RequestContext, params::ListPromptsParams)::Ha
             )
             !isnothing(prompt.title) && (d["title"] = prompt.title)
             !isnothing(prompt.icons) && (d["icons"] = [icon_to_dict(i) for i in prompt.icons])
+            !isnothing(prompt._meta) && (d["_meta"] = prompt._meta)
             d
         end
 
@@ -445,6 +447,7 @@ function handle_list_resources(ctx::RequestContext, params::ListResourcesParams)
             )
             !isnothing(resource.title) && (d["title"] = resource.title)
             !isnothing(resource.icons) && (d["icons"] = [icon_to_dict(i) for i in resource.icons])
+            !isnothing(resource._meta) && (d["_meta"] = resource._meta)
             d
         end
 
@@ -682,8 +685,11 @@ function handle_list_tools(ctx::RequestContext, params::ListToolsParams)::Handle
                 # Use the raw input_schema directly
                 tool.input_schema
             else
-                # Build schema from parameters (original behavior)
+                # Build schema from parameters (original behavior). Declare the
+                # JSON Schema dialect the MCP spec defaults to (2020-12); a raw
+                # input_schema above is passed through verbatim, dialect included.
                 LittleDict{String,Any}(
+                    "\$schema" => "https://json-schema.org/draft/2020-12/schema",
                     "type" => "object",
                     "properties" => Dict(
                         param.name => begin
@@ -711,6 +717,7 @@ function handle_list_tools(ctx::RequestContext, params::ListToolsParams)::Handle
             !isnothing(tool.icons) && (d["icons"] = [icon_to_dict(i) for i in tool.icons])
             !isnothing(tool.annotations) && (d["annotations"] = tool.annotations)
             !isnothing(tool.output_schema) && (d["outputSchema"] = tool.output_schema)
+            !isnothing(tool._meta) && (d["_meta"] = tool._meta)
             d
         end
 

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -284,7 +284,7 @@ function handle_list_prompts(ctx::RequestContext, params::ListPromptsParams)::Ha
     end
 end
 
-function process_template(text::String, arguments::Dict{String,String})
+function process_template(text::String, arguments::AbstractDict{String,String})
     # Handle the text character by character to ensure proper brace matching
     result = text
     

--- a/src/protocol/messages.jl
+++ b/src/protocol/messages.jl
@@ -31,17 +31,23 @@ Base.@kwdef struct ClientCapabilities
 end
 
 """
-    Implementation(; name::String="default-client", version::String="1.0.0")
+    Implementation(; name::String="default-client", version::String="1.0.0",
+                   title::Union{String,Nothing}=nothing,
+                   description::Union{String,Nothing}=nothing)
 
 Information about a client or server implementation of the MCP protocol.
 
 # Fields
 - `name::String`: Name of the implementation
 - `version::String`: Version string of the implementation
+- `title::Union{String,Nothing}`: Optional human-readable display name
+- `description::Union{String,Nothing}`: Optional human-readable description (MCP 2025-11-25)
 """
 Base.@kwdef struct Implementation
     name::String = "default-client"
     version::String = "1.0.0"
+    title::Union{String,Nothing} = nothing
+    description::Union{String,Nothing} = nothing
 end
 
 """
@@ -188,12 +194,18 @@ Result returned from a tool invocation.
 - `is_error::Bool`: Whether the tool execution resulted in an error
 - `structured_content::Union{Nothing,AbstractDict}`: Optional structured result (a JSON
   object per the MCP spec), serialized as `structuredContent` and omitted when `nothing`.
-  Pair it with the tool's `output_schema` so clients can validate and consume it programmatically.
+  Pair it with the tool's `output_schema` so clients can validate and consume it
+  programmatically. Per the spec, a tool returning structured content SHOULD also include
+  a human-readable serialization (e.g. the JSON as text) in `content` for clients that
+  don't consume structured output.
+- `_meta::Union{Nothing,AbstractDict}`: Optional result metadata for protocol extensions,
+  serialized as `_meta` and omitted when `nothing`
 """
 Base.@kwdef struct CallToolResult <: ResponseResult
     content::Vector{Dict{String,Any}}
     is_error::Bool = false
     structured_content::Union{Nothing,AbstractDict} = nothing
+    _meta::Union{Nothing,AbstractDict} = nothing
 end
 
 #= Prompt-Related Messages =#

--- a/src/transports/base.jl
+++ b/src/transports/base.jl
@@ -83,6 +83,23 @@ never corrupts that request's response.
 send_notification(transport::Transport, message::String) = write_message(transport, message)
 
 """
+    set_negotiated_version!(transport::Transport, version::String) -> Nothing
+
+Inform the transport of the protocol version negotiated during `initialize`, so
+transports that advertise a version per response (e.g. the HTTP `MCP-Protocol-Version`
+header) echo the negotiated one rather than a static default. Default is a no-op
+(stdio carries no version metadata).
+
+# Arguments
+- `transport::Transport`: The transport instance to update
+- `version::String`: The negotiated MCP protocol version
+
+# Returns
+- `Nothing`
+"""
+set_negotiated_version!(::Transport, ::String) = nothing
+
+"""
     close(transport::Transport) -> Nothing
 
 Close the transport connection and clean up resources.

--- a/src/transports/http.jl
+++ b/src/transports/http.jl
@@ -791,6 +791,18 @@ end
 
 
 """
+    set_negotiated_version!(transport::HttpTransport, version::String) -> Nothing
+
+Update the version advertised in `MCP-Protocol-Version` response headers (and accepted
+in request headers) to the version negotiated during `initialize`, so per-request
+headers echo what the initialize response returned.
+"""
+function set_negotiated_version!(transport::HttpTransport, version::String)
+    transport.protocol_version = version
+    nothing
+end
+
+"""
     send_notification(transport::HttpTransport, notification::String) -> Nothing
 
 Send a notification to all connected SSE streams.

--- a/src/types.jl
+++ b/src/types.jl
@@ -176,6 +176,28 @@ Base.@kwdef struct ImageContent <: Content
 end
 
 """
+    AudioContent(; type::String="audio", data::Vector{UInt8}, mime_type::String,
+                 annotations::Union{Nothing,Dict{String,Any}}=nothing,
+                 _meta::Union{Nothing,Dict{String,Any}}=nothing) <: Content
+
+Audio content for messages and tool responses (protocol 2025-03-26+).
+
+# Fields
+- `type::String`: Content type identifier (always "audio")
+- `data::Vector{UInt8}`: Raw audio data (automatically base64-encoded when serialized)
+- `mime_type::String`: MIME type of the audio (e.g., "audio/wav"), serialized as `mimeType`
+- `annotations::Union{Nothing,Dict{String,Any}}`: Optional annotations for the client
+- `_meta::Union{Nothing,Dict{String,Any}}`: Optional metadata for protocol extensions
+"""
+Base.@kwdef struct AudioContent <: Content
+    type::String = "audio"
+    data::Vector{UInt8}
+    mime_type::String
+    annotations::Union{Nothing,Dict{String,Any}} = nothing
+    _meta::Union{Nothing,Dict{String,Any}} = nothing
+end
+
+"""
     TextResourceContents(; uri::URI, mime_type::String="text/plain", text::String) <: ResourceContents
 
 Text content for resources in the MCP protocol.
@@ -229,23 +251,32 @@ Base.@kwdef struct EmbeddedResource <: Content
 end
 
 """
-    ResourceLink(; type::String="link", href::String, 
+    ResourceLink(; type::String="resource_link", uri::String, name::String,
+                 description::Union{String,Nothing}=nothing,
+                 mime_type::Union{String,Nothing}=nothing,
                  title::Union{String,Nothing}=nothing,
                  annotations::Union{Nothing,Dict{String,Any}}=nothing,
                  _meta::Union{Nothing,Dict{String,Any}}=nothing) <: Content
 
-Link to an external resource (NEW in protocol 2025-06-18).
+Link to a resource a tool result can reference without embedding it (protocol 2025-06-18).
+Serialized per the MCP spec as `{"type": "resource_link", "uri": ..., "name": ..., ...}`.
 
 # Fields
-- `type::String`: Content type identifier (always "link")
-- `href::String`: URL or URI of the linked resource
-- `title::Union{String,Nothing}`: Optional human-readable title for the link
+- `type::String`: Content type identifier (always "resource_link")
+- `uri::String`: URI of the linked resource
+- `name::String`: Name of the resource
+- `description::Union{String,Nothing}`: Optional description of the resource
+- `mime_type::Union{String,Nothing}`: Optional MIME type, serialized as `mimeType`
+- `title::Union{String,Nothing}`: Optional human-readable title
 - `annotations::Union{Nothing,Dict{String,Any}}`: Optional annotations for the client
 - `_meta::Union{Nothing,Dict{String,Any}}`: Optional metadata for protocol extensions
 """
 Base.@kwdef struct ResourceLink <: Content
-    type::String = "link"
-    href::String
+    type::String = "resource_link"
+    uri::String
+    name::String
+    description::Union{String,Nothing} = nothing
+    mime_type::Union{String,Nothing} = nothing
     title::Union{String,Nothing} = nothing
     annotations::Union{Nothing,Dict{String,Any}} = nothing
     _meta::Union{Nothing,Dict{String,Any}} = nothing
@@ -330,6 +361,8 @@ Implement a tool that can be invoked by clients in the MCP protocol.
 - `output_schema::Union{Nothing,AbstractDict}`: Optional JSON Schema for the tool's
   structured result, emitted as `outputSchema` in `tools/list`. Pair it with a
   `CallToolResult(structured_content=…)` so clients can validate the structured output.
+- `_meta::Union{Nothing,Dict{String,Any}}`: Optional metadata for protocol extensions,
+  emitted verbatim in `tools/list` when set
 
 # Parameter Definition
 Tools can define parameters in two ways:
@@ -364,6 +397,7 @@ Base.@kwdef struct MCPTool <: Tool
     icons::Union{Vector{MCPIcon},Nothing} = nothing
     annotations::Union{Nothing,Dict{String,Any}} = nothing
     output_schema::Union{Nothing,AbstractDict} = nothing
+    _meta::Union{Nothing,Dict{String,Any}} = nothing  # emitted verbatim in tools/list when set
 end
 
 #==============================================================================
@@ -390,31 +424,31 @@ Base.@kwdef struct PromptArgument
 end
 
 """
-    PromptMessage(; content::Union{TextContent, ImageContent, EmbeddedResource}, role::Role=user)
+    PromptMessage(; content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}, role::Role=user)
 
 Represent a single message in a prompt template.
 
 # Fields
-- `content::Union{TextContent, ImageContent, EmbeddedResource}`: The content of the message
+- `content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}`: The content of the message
 - `role::Role`: Whether this message is from the user or assistant (defaults to user)
 """
 Base.@kwdef struct PromptMessage
-    content::Union{TextContent, ImageContent, EmbeddedResource}
+    content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}
     role::Role = user  # Set default in the kwdef constructor
 end
 
 """
-    PromptMessage(content::Union{TextContent, ImageContent, EmbeddedResource}) -> PromptMessage
+    PromptMessage(content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}) -> PromptMessage
 
 Create a prompt message with only content (role defaults to user).
 
 # Arguments
-- `content::Union{TextContent, ImageContent, EmbeddedResource}`: The message content
+- `content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}`: The message content
 
 # Returns
 - `PromptMessage`: A new prompt message with the default user role
 """
-function PromptMessage(content::Union{TextContent, ImageContent, EmbeddedResource})
+function PromptMessage(content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource})
     PromptMessage(content = content)
 end
 
@@ -435,6 +469,8 @@ Prompts can include variables that are replaced with arguments when retrieved.
 - `messages::Vector{PromptMessage}`: The sequence of messages in the prompt
 - `title::Union{String,Nothing}`: Optional human-friendly display name
 - `icons::Union{Vector{MCPIcon},Nothing}`: Optional icons for UI display
+- `_meta::Union{Nothing,Dict{String,Any}}`: Optional metadata for protocol extensions,
+  emitted verbatim in `prompts/list` when set
 """
 Base.@kwdef struct MCPPrompt
     name::String
@@ -443,6 +479,7 @@ Base.@kwdef struct MCPPrompt
     messages::Vector{PromptMessage} = PromptMessage[]
     title::Union{String,Nothing} = nothing
     icons::Union{Vector{MCPIcon},Nothing} = nothing
+    _meta::Union{Nothing,Dict{String,Any}} = nothing  # emitted verbatim in prompts/list when set
 end
 
 """
@@ -495,6 +532,7 @@ struct MCPResource <: Resource
     annotations::AbstractDict{String,Any}
     title::Union{String,Nothing}
     icons::Union{Vector{MCPIcon},Nothing}
+    _meta::Union{Nothing,Dict{String,Any}}  # emitted verbatim in resources/list when set
 end
 
 """
@@ -515,6 +553,8 @@ Create a resource with automatic URI conversion from strings or URIs.
 - `annotations::AbstractDict{String,Any}`: Additional metadata for the resource
 - `title::Union{String,Nothing}`: Optional human-friendly display name
 - `icons::Union{Vector{MCPIcon},Nothing}`: Optional icons for UI display
+- `_meta::Union{Nothing,Dict{String,Any}}`: Optional metadata for protocol extensions,
+  emitted verbatim in `resources/list` when set
 
 # Returns
 - `MCPResource`: A new resource with the provided configuration
@@ -526,9 +566,10 @@ function MCPResource(; uri,
     data_provider::Function,
     annotations::AbstractDict{String,Any} = LittleDict{String,Any}(),
     title::Union{String,Nothing} = nothing,
-    icons::Union{Vector{MCPIcon},Nothing} = nothing)
+    icons::Union{Vector{MCPIcon},Nothing} = nothing,
+    _meta::Union{Nothing,Dict{String,Any}} = nothing)
     uri_obj = uri isa URI ? uri : URI(uri)
-    MCPResource(uri_obj, name, description, mime_type, data_provider, annotations, title, icons)
+    MCPResource(uri_obj, name, description, mime_type, data_provider, annotations, title, icons, _meta)
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -267,6 +267,7 @@ Serialized per the MCP spec as `{"type": "resource_link", "uri": ..., "name": ..
 - `name::String`: Name of the resource
 - `description::Union{String,Nothing}`: Optional description of the resource
 - `mime_type::Union{String,Nothing}`: Optional MIME type, serialized as `mimeType`
+- `size::Union{Int,Nothing}`: Optional resource size in bytes
 - `title::Union{String,Nothing}`: Optional human-readable title
 - `annotations::Union{Nothing,Dict{String,Any}}`: Optional annotations for the client
 - `_meta::Union{Nothing,Dict{String,Any}}`: Optional metadata for protocol extensions
@@ -277,6 +278,7 @@ Base.@kwdef struct ResourceLink <: Content
     name::String
     description::Union{String,Nothing} = nothing
     mime_type::Union{String,Nothing} = nothing
+    size::Union{Int,Nothing} = nothing
     title::Union{String,Nothing} = nothing
     annotations::Union{Nothing,Dict{String,Any}} = nothing
     _meta::Union{Nothing,Dict{String,Any}} = nothing
@@ -424,31 +426,31 @@ Base.@kwdef struct PromptArgument
 end
 
 """
-    PromptMessage(; content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}, role::Role=user)
+    PromptMessage(; content::Union{TextContent, ImageContent, AudioContent, ResourceLink, EmbeddedResource}, role::Role=user)
 
 Represent a single message in a prompt template.
 
 # Fields
-- `content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}`: The content of the message
+- `content::Union{TextContent, ImageContent, AudioContent, ResourceLink, EmbeddedResource}`: The content of the message
 - `role::Role`: Whether this message is from the user or assistant (defaults to user)
 """
 Base.@kwdef struct PromptMessage
-    content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}
+    content::Union{TextContent, ImageContent, AudioContent, ResourceLink, EmbeddedResource}
     role::Role = user  # Set default in the kwdef constructor
 end
 
 """
-    PromptMessage(content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}) -> PromptMessage
+    PromptMessage(content::Union{TextContent, ImageContent, AudioContent, ResourceLink, EmbeddedResource}) -> PromptMessage
 
 Create a prompt message with only content (role defaults to user).
 
 # Arguments
-- `content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource}`: The message content
+- `content::Union{TextContent, ImageContent, AudioContent, ResourceLink, EmbeddedResource}`: The message content
 
 # Returns
 - `PromptMessage`: A new prompt message with the default user role
 """
-function PromptMessage(content::Union{TextContent, ImageContent, AudioContent, EmbeddedResource})
+function PromptMessage(content::Union{TextContent, ImageContent, AudioContent, ResourceLink, EmbeddedResource})
     PromptMessage(content = content)
 end
 

--- a/src/utils/serialization.jl
+++ b/src/utils/serialization.jl
@@ -10,6 +10,7 @@ This module configures how various MCP types are serialized to and from JSON.
 # Add StructTypes support for JSON serialization
 StructTypes.StructType(::Type{TextContent}) = StructTypes.Struct()
 StructTypes.StructType(::Type{ImageContent}) = StructTypes.Struct()
+StructTypes.StructType(::Type{AudioContent}) = StructTypes.Struct()
 StructTypes.StructType(::Type{TextResourceContents}) = StructTypes.Struct()
 StructTypes.StructType(::Type{BlobResourceContents}) = StructTypes.Struct()
 StructTypes.StructType(::Type{EmbeddedResource}) = StructTypes.Struct()
@@ -64,12 +65,12 @@ clients rely on it to detect tool errors) and `structured_content` → `structur
 StructTypes.names(::Type{CallToolResult}) = ((:is_error, :isError), (:structured_content, :structuredContent))
 
 """
-    StructTypes.omitempties(::Type{CallToolResult}) -> Tuple{Symbol}
+    StructTypes.omitempties(::Type{CallToolResult}) -> Tuple{Symbol,Symbol}
 
-Omit `structured_content` from the response when it is `nothing`, so tools that
-don't produce structured output emit no `structuredContent` key.
+Omit `structured_content` and `_meta` from the response when they are `nothing`, so
+tools that don't use them emit no `structuredContent`/`_meta` keys.
 """
-StructTypes.omitempties(::Type{CallToolResult}) = (:structured_content,)
+StructTypes.omitempties(::Type{CallToolResult}) = (:structured_content, :_meta)
 
 """
     content2dict(content::Content) -> Dict{String,Any}
@@ -116,6 +117,19 @@ function content2dict(content::ImageContent)
     return result
 end
 
+# AudioContent conversion
+function content2dict(content::AudioContent)
+    result = LittleDict{String,Any}(
+        "type" => "audio",
+        "data" => base64encode(content.data),
+        "mimeType" => content.mime_type
+    )
+    # Add optional fields if present
+    !isnothing(content.annotations) && (result["annotations"] = content.annotations)
+    !isnothing(content._meta) && (result["_meta"] = content._meta)
+    return result
+end
+
 # EmbeddedResource conversion
 function content2dict(content::EmbeddedResource)
     result = LittleDict{String,Any}(
@@ -131,15 +145,18 @@ end
 # ResourceLink conversion (new in MCP protocol 2025-06-18)
 function content2dict(content::ResourceLink)
     result = LittleDict{String,Any}(
-        "type" => "link",
-        "href" => content.href
+        "type" => "resource_link",
+        "uri" => content.uri,
+        "name" => content.name
     )
-    
+
     # Add optional fields if present
+    !isnothing(content.description) && (result["description"] = content.description)
+    !isnothing(content.mime_type) && (result["mimeType"] = content.mime_type)
     !isnothing(content.title) && (result["title"] = content.title)
     !isnothing(content.annotations) && (result["annotations"] = content.annotations)
     !isnothing(content._meta) && (result["_meta"] = content._meta)
-    
+
     return result
 end
 

--- a/src/utils/serialization.jl
+++ b/src/utils/serialization.jl
@@ -153,6 +153,7 @@ function content2dict(content::ResourceLink)
     # Add optional fields if present
     !isnothing(content.description) && (result["description"] = content.description)
     !isnothing(content.mime_type) && (result["mimeType"] = content.mime_type)
+    !isnothing(content.size) && (result["size"] = content.size)
     !isnothing(content.title) && (result["title"] = content.title)
     !isnothing(content.annotations) && (result["annotations"] = content.annotations)
     !isnothing(content._meta) && (result["_meta"] = content._meta)

--- a/test/e2e/fixtures/wire_demo_server.jl
+++ b/test/e2e/fixtures/wire_demo_server.jl
@@ -1,0 +1,84 @@
+# test/e2e/fixtures/wire_demo_server.jl
+#
+# Demo server exercising every wire-visible feature in one place: server
+# description, generated input schema ($schema dialect), _meta on components
+# and results, multi-content tool returns (text + audio + resource_link),
+# structured output, and media prompt messages. Driven as a real subprocess
+# by test/e2e/test_wire_conformance.jl over stdio (default) and Streamable
+# HTTP (`http` argument; port from DEMO_PORT, default 8772).
+
+using ModelContextProtocol
+
+audio_bytes = UInt8[0x52, 0x49, 0x46, 0x46]  # "RIFF"
+png_bytes = UInt8[0x89, 0x50, 0x4E, 0x47]    # PNG header
+
+analyze = MCPTool(
+    name = "analyze_image",
+    description = "Fake analysis returning text + audio + resource_link",
+    parameters = [
+        ToolParameter(name = "dataset", description = "Dataset name", type = "string", required = true),
+    ],
+    handler = args -> [
+        TextContent(text = "analyzed $(args["dataset"])"),
+        AudioContent(data = audio_bytes, mime_type = "audio/wav"),
+        ResourceLink(
+            uri = "file:///results/$(args["dataset"])/overlay.png",
+            name = "overlay.png",
+            description = "Segmentation overlay",
+            mime_type = "image/png",
+            size = 123456,
+        ),
+    ],
+    _meta = Dict{String,Any}("lab/origin" => "wire-demo"),
+)
+
+structured = MCPTool(
+    name = "get_stats",
+    description = "Structured output demo",
+    parameters = [],
+    output_schema = Dict{String,Any}(
+        "type" => "object",
+        "properties" => Dict{String,Any}("count" => Dict{String,Any}("type" => "integer")),
+    ),
+    handler = args -> CallToolResult(
+        content = [Dict{String,Any}("type" => "text", "text" => "{\"count\":42}")],
+        structured_content = Dict("count" => 42),
+        _meta = Dict("trace" => "abc123"),
+    ),
+)
+
+media_prompt = MCPPrompt(
+    name = "media_demo",
+    description = "Prompt with all media content types",
+    messages = [
+        PromptMessage(content = TextContent(text = "Look at this:")),
+        PromptMessage(content = ImageContent(data = png_bytes, mime_type = "image/png")),
+        PromptMessage(content = AudioContent(data = audio_bytes, mime_type = "audio/wav")),
+        PromptMessage(content = ResourceLink(uri = "file:///d/raw.tif", name = "raw.tif")),
+    ],
+    _meta = Dict{String,Any}("lab/prompt" => true),
+)
+
+res = MCPResource(
+    uri = "demo://stats",
+    name = "stats",
+    description = "Demo resource",
+    data_provider = () -> Dict("ok" => true),
+    _meta = Dict{String,Any}("lab/resource" => 1),
+)
+
+server = mcp_server(
+    name = "wire-demo",
+    version = "0.1.0",
+    description = "Wire conformance demo server",
+    tools = [analyze, structured],
+    prompts = [media_prompt],
+    resources = [res],
+)
+
+if "http" in ARGS
+    port = parse(Int, get(ENV, "DEMO_PORT", "8772"))
+    server.transport = HttpTransport(host = "127.0.0.1", port = port)
+    ModelContextProtocol.connect(server.transport)
+end
+start!(server)

--- a/test/e2e/test_wire_conformance.jl
+++ b/test/e2e/test_wire_conformance.jl
@@ -1,0 +1,131 @@
+# test/e2e/test_wire_conformance.jl
+#
+# Wire-format conformance against a REAL server subprocess (the fixture in
+# fixtures/wire_demo_server.jl), over both transports. In-process handler tests
+# can't see what a client actually receives — serialized bodies and HTTP
+# headers — so spec-shape regressions (e.g. ResourceLink once emitting
+# non-spec {"type":"link","href":...}, or prompts/get leaking raw struct
+# fields) only show up here. Gated by RUN_E2E like the other e2e tests; no
+# `using` here by convention (runtests.jl provides Test, ModelContextProtocol,
+# JSON3, HTTP, Base64).
+
+const _WIRE_FIXTURE = joinpath(_E2E_REPO, "test", "e2e", "fixtures", "wire_demo_server.jl")
+
+const _WIRE_REQUESTS = [
+    """{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"wire-e2e","version":"1.0"}},"id":1}""",
+    """{"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}""",
+    """{"jsonrpc":"2.0","method":"tools/call","params":{"name":"analyze_image","arguments":{"dataset":"run42"}},"id":3}""",
+    """{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_stats","arguments":{}},"id":4}""",
+    """{"jsonrpc":"2.0","method":"prompts/get","params":{"name":"media_demo"},"id":5}""",
+    """{"jsonrpc":"2.0","method":"resources/list","params":{},"id":6}""",
+]
+
+# Shared assertions on the six responses (Dict id => parsed JSON3 object),
+# used by both the stdio and HTTP passes.
+function _wire_assert(resp)
+    # 1: initialize — negotiated version + serverInfo.description
+    @test resp[1].result.protocolVersion == "2025-06-18"
+    @test resp[1].result.serverInfo.description == "Wire conformance demo server"
+
+    # 2: tools/list — generated schema declares 2020-12; _meta and outputSchema emitted
+    tools = Dict(String(t.name) => t for t in resp[2].result.tools)
+    @test tools["analyze_image"].inputSchema["\$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    @test tools["analyze_image"]._meta["lab/origin"] == "wire-demo"
+    @test tools["get_stats"].outputSchema["type"] == "object"
+
+    # 3: multi-content call — spec audio + resource_link shapes
+    content = resp[3].result.content
+    @test [String(c.type) for c in content] == ["text", "audio", "resource_link"]
+    @test content[2].mimeType == "audio/wav"
+    @test content[2].data == base64encode(UInt8[0x52, 0x49, 0x46, 0x46])
+    @test content[3].uri == "file:///results/run42/overlay.png"
+    @test content[3].name == "overlay.png"
+    @test content[3].size == 123456
+    @test !haskey(content[3], :href)             # the old non-spec key
+    @test resp[3].result.isError == false        # spec key, not is_error
+    @test !haskey(resp[3].result, :is_error)
+
+    # 4: structured output — structuredContent + result _meta
+    @test resp[4].result.structuredContent.count == 42
+    @test resp[4].result._meta.trace == "abc123"
+
+    # 5: prompts/get — works WITHOUT arguments; media in spec wire format
+    msgs = resp[5].result.messages
+    @test [String(m.role) for m in msgs] == ["user", "user", "user", "user"]
+    @test [String(m.content.type) for m in msgs] == ["text", "image", "audio", "resource_link"]
+    for m in msgs
+        @test !haskey(m.content, :mime_type)     # no raw Julia field names on the wire
+    end
+    @test msgs[3].content.mimeType == "audio/wav"
+    @test msgs[3].content.data == base64encode(UInt8[0x52, 0x49, 0x46, 0x46])
+    @test msgs[4].content.uri == "file:///d/raw.tif"
+
+    # 6: resources/list — _meta emitted
+    @test resp[6].result.resources[1]._meta["lab/resource"] == 1
+end
+
+@testset "E2E wire conformance (real subprocesses)" begin
+
+    @testset "stdio" begin
+        @test isfile(_WIRE_FIXTURE)
+        out = read(pipeline(`$(_E2E_JULIA) --project=$(_E2E_REPO) $(_WIRE_FIXTURE)`;
+                            stdin = IOBuffer(join(_WIRE_REQUESTS, "\n") * "\n"),
+                            stderr = devnull), String)
+        resp = Dict{Int,Any}()
+        for line in split(out, '\n')
+            startswith(line, "{") || continue
+            msg = JSON3.read(line)
+            haskey(msg, :id) && (resp[msg.id] = msg)
+        end
+        @test length(resp) == 6
+        length(resp) == 6 && _wire_assert(resp)
+    end
+
+    @testset "Streamable HTTP" begin
+        port = 8772
+        url = "http://127.0.0.1:$(port)/"
+        if _e2e_http_alive(url)
+            @warn "Port $(port) is already serving HTTP; skipping HTTP wire-conformance test"
+        else
+            proc = run(pipeline(addenv(`$(_E2E_JULIA) --project=$(_E2E_REPO) $(_WIRE_FIXTURE) http`,
+                                       "DEMO_PORT" => string(port));
+                                stdout = devnull, stderr = devnull); wait = false)
+            try
+                ready = false
+                for _ in 1:90
+                    _e2e_http_alive(url) && (ready = true; break)
+                    sleep(1)
+                end
+                @test ready
+                if ready
+                    hdrs = ["Content-Type" => "application/json",
+                            "Accept" => "application/json, text/event-stream"]
+                    resp = Dict{Int,Any}()
+                    session = ""
+                    versions = String[]
+                    for req in _WIRE_REQUESTS
+                        h = isempty(session) ? hdrs : vcat(hdrs, ["Mcp-Session-Id" => session])
+                        r = HTTP.post(url, h, req; status_exception = false)
+                        @test r.status == 200
+                        push!(versions, HTTP.header(r, "MCP-Protocol-Version", ""))
+                        isempty(session) && (session = HTTP.header(r, "Mcp-Session-Id", ""))
+                        msg = JSON3.read(String(r.body))
+                        haskey(msg, :id) && (resp[msg.id] = msg)
+                    end
+                    # The response HEADER echoes the NEGOTIATED version on every
+                    # response (client asked 2025-06-18; transport default is latest)
+                    @test all(==("2025-06-18"), versions)
+                    @test length(resp) == 6
+                    length(resp) == 6 && _wire_assert(resp)
+                end
+            finally
+                kill(proc)
+                try
+                    wait(proc)
+                catch
+                end
+            end
+        end
+    end
+
+end

--- a/test/features/prompts.jl
+++ b/test/features/prompts.jl
@@ -27,6 +27,22 @@
     @test result.response.result["messages"][1]["content"]["text"] == "Test prompt with World"
 end
 
+@testset "prompts/get works without arguments" begin
+    # Regression: the no-arguments path passes a LittleDict to process_template,
+    # which was typed ::Dict and threw a MethodError (found by live-server testing)
+    prompt = MCPPrompt(
+        name = "no-args-prompt",
+        description = "Text prompt fetched without arguments",
+        messages = [PromptMessage(content = TextContent(text = "Hello, plain prompt"))]
+    )
+    server = Server(ServerConfig(name = "test"))
+    register!(server, prompt)
+    ctx = RequestContext(server = server, request_id = 1)
+    result = handle_get_prompt(ctx, GetPromptParams(name = "no-args-prompt"))
+    @test isnothing(result.error)
+    @test result.response.result["messages"][1]["content"]["text"] == "Hello, plain prompt"
+end
+
 @testset "prompts/get media content uses spec wire format" begin
     audio = AudioContent(data = [0x52, 0x49, 0x46, 0x46], mime_type = "audio/wav")
     image = ImageContent(data = [0x89, 0x50], mime_type = "image/png")

--- a/test/features/prompts.jl
+++ b/test/features/prompts.jl
@@ -23,6 +23,42 @@
     @test result isa HandlerResult
     @test !isnothing(result.response)
     @test result.response isa JSONRPCResponse
-    @test result.response.result isa GetPromptResult
-    @test result.response.result.messages[1].content.text == "Test prompt with World"
+    @test result.response.result["messages"][1]["role"] == "user"
+    @test result.response.result["messages"][1]["content"]["text"] == "Test prompt with World"
+end
+
+@testset "prompts/get media content uses spec wire format" begin
+    audio = AudioContent(data = [0x52, 0x49, 0x46, 0x46], mime_type = "audio/wav")
+    image = ImageContent(data = [0x89, 0x50], mime_type = "image/png")
+    link = ResourceLink(uri = "file:///data/run42.tif", name = "run42.tif", size = 1024)
+    prompt = MCPPrompt(
+        name = "media-prompt",
+        description = "Prompt with media content",
+        messages = [
+            PromptMessage(content = audio),
+            PromptMessage(content = image, role = ModelContextProtocol.assistant),
+            PromptMessage(content = link),
+        ]
+    )
+    server = Server(ServerConfig(name = "test"))
+    register!(server, prompt)
+    ctx = RequestContext(server = server, request_id = 1)
+    result = handle_get_prompt(ctx, GetPromptParams(name = "media-prompt"))
+    messages = result.response.result["messages"]
+
+    # Audio: base64 data + mimeType (not raw bytes / mime_type)
+    @test messages[1]["content"]["type"] == "audio"
+    @test messages[1]["content"]["data"] == base64encode([0x52, 0x49, 0x46, 0x46])
+    @test messages[1]["content"]["mimeType"] == "audio/wav"
+    @test !haskey(messages[1]["content"], "mime_type")
+
+    # Image: same spec shape, assistant role serialized as string
+    @test messages[2]["role"] == "assistant"
+    @test messages[2]["content"]["data"] == base64encode([0x89, 0x50])
+    @test messages[2]["content"]["mimeType"] == "image/png"
+
+    # ResourceLink is valid prompt content and carries size
+    @test messages[3]["content"]["type"] == "resource_link"
+    @test messages[3]["content"]["uri"] == "file:///data/run42.tif"
+    @test messages[3]["content"]["size"] == 1024
 end

--- a/test/features/resources.jl
+++ b/test/features/resources.jl
@@ -1,4 +1,66 @@
-# No specific resource tests in original suite yet - placeholder for future tests
 @testset "Resource Tests" begin
-    @test true  # Placeholder
+    @testset "resources/read returns provider data" begin
+        resource = MCPResource(
+            uri = "test://config",
+            name = "config",
+            description = "Test configuration",
+            data_provider = () -> Dict("threshold" => 42),
+        )
+        server = mcp_server(name = "test", version = "1.0.0", resources = [resource])
+        ctx = RequestContext(server = server, request_id = 1)
+
+        result = handle_read_resource(ctx, ReadResourceParams(uri = "test://config"))
+        @test isnothing(result.error)
+        contents = result.response.result.contents[1]
+        @test contents["uri"] == "test://config"
+        @test contents["mimeType"] == "application/json"  # MCPResource default
+        @test JSON3.read(contents["text"])["threshold"] == 42
+    end
+
+    @testset "resources/read unknown URI is a resource error" begin
+        server = mcp_server(name = "test", version = "1.0.0")
+        ctx = RequestContext(server = server, request_id = 1)
+        result = handle_read_resource(ctx, ReadResourceParams(uri = "test://missing"))
+        @test isnothing(result.response)
+        @test result.error.code == Int(ModelContextProtocol.ErrorCodes.RESOURCE_NOT_FOUND)
+    end
+
+    @testset "resources/read with a throwing data_provider returns an error result" begin
+        bad = MCPResource(
+            uri = "test://broken",
+            name = "broken",
+            data_provider = () -> error("backend down"),
+        )
+        server = mcp_server(name = "test", version = "1.0.0", resources = [bad])
+        ctx = RequestContext(server = server, request_id = 1)
+        result = handle_read_resource(ctx, ReadResourceParams(uri = "test://broken"))
+        @test isnothing(result.response)  # errors surface as JSON-RPC errors, not throws
+        @test !isnothing(result.error)
+    end
+end
+
+@testset "Resource Subscriptions" begin
+    server = mcp_server(name = "test", version = "1.0.0")
+    uri = "test://watched"
+    cb1 = _ -> nothing
+    cb2 = _ -> nothing
+
+    # subscribe! registers callbacks per URI (and returns the server for chaining)
+    @test subscribe!(server, uri, cb1) === server
+    subscribe!(server, uri, cb2)
+    @test length(server.subscriptions[uri]) == 2
+    @test server.subscriptions[uri][1].uri == uri
+    @test server.subscriptions[uri][1].callback === cb1
+
+    # unsubscribe! removes exactly the matching callback
+    @test unsubscribe!(server, uri, cb1) === server
+    @test length(server.subscriptions[uri]) == 1
+    @test server.subscriptions[uri][1].callback === cb2
+
+    # unsubscribing an unknown callback is a no-op, not an error
+    unsubscribe!(server, uri, _ -> nothing)
+    @test length(server.subscriptions[uri]) == 1
+
+    # unseen URIs read as empty (DefaultDict), no KeyError
+    @test isempty(server.subscriptions["test://never-subscribed"])
 end

--- a/test/protocol/handlers.jl
+++ b/test/protocol/handlers.jl
@@ -64,6 +64,19 @@ end
         server_info = result.response.result.serverInfo
         @test !haskey(server_info, "title")
         @test !haskey(server_info, "icons")
+        @test !haskey(server_info, "description")  # default description is ""
+    end
+
+    @testset "ServerInfo includes description" begin
+        server = mcp_server(name="desc-test", version="1.0.0", description="A demo MCP server")
+        ctx = RequestContext(server=server, request_id=1)
+        init_params = InitializeParams(
+            capabilities=ClientCapabilities(),
+            clientInfo=Implementation(),
+            protocolVersion="2025-06-18"
+        )
+        result = handle_initialize(ctx, init_params)
+        @test result.response.result.serverInfo["description"] == "A demo MCP server"
     end
 
     @testset "Tools list includes title and icons" begin
@@ -130,6 +143,51 @@ end
         @test haskey(tool_dict["outputSchema"]["properties"], "answer")
     end
 
+    @testset "Generated input schema declares the 2020-12 dialect" begin
+        param_tool = MCPTool(
+            name="param_tool",
+            description="Schema built from parameters",
+            parameters=[ToolParameter(name="x", description="X", type="string", required=true)],
+            handler=(args) -> TextContent(text="ok")
+        )
+        raw_schema = Dict{String,Any}("type" => "object", "properties" => Dict{String,Any}())
+        raw_tool = MCPTool(
+            name="raw_tool",
+            description="User-provided raw schema",
+            parameters=[],
+            input_schema=raw_schema,
+            handler=(args) -> TextContent(text="ok")
+        )
+        server = mcp_server(name="test", version="1.0.0", tools=[param_tool, raw_tool])
+        ctx = RequestContext(server=server, request_id=1)
+        result = ModelContextProtocol.handle_list_tools(ctx, ModelContextProtocol.ListToolsParams())
+        tools = result.response.result["tools"]
+        generated = only(filter(t -> t["name"] == "param_tool", tools))["inputSchema"]
+        raw = only(filter(t -> t["name"] == "raw_tool", tools))["inputSchema"]
+        @test generated["\$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        @test haskey(generated["properties"], "x")
+        @test !haskey(raw, "\$schema")  # raw input_schema passes through verbatim
+    end
+
+    @testset "List entries include _meta when set" begin
+        meta = Dict{String,Any}("vendor/key" => "v")
+        tool = MCPTool(name="meta_tool", description="t", parameters=[],
+                       handler=(args) -> TextContent(text="ok"), _meta=meta)
+        prompt = MCPPrompt(name="meta_prompt", description="p", _meta=meta)
+        resource = MCPResource(uri="test://meta", name="meta_res",
+                               data_provider=() -> Dict(), _meta=meta)
+        server = mcp_server(name="test", version="1.0.0",
+                            tools=[tool], prompts=[prompt], resources=[resource])
+        ctx = RequestContext(server=server, request_id=1)
+
+        tool_dict = ModelContextProtocol.handle_list_tools(ctx, ModelContextProtocol.ListToolsParams()).response.result["tools"][1]
+        prompt_dict = ModelContextProtocol.handle_list_prompts(ctx, ModelContextProtocol.ListPromptsParams()).response.result["prompts"][1]
+        res_dict = handle_list_resources(ctx, ListResourcesParams()).response.result["resources"][1]
+        @test tool_dict["_meta"]["vendor/key"] == "v"
+        @test prompt_dict["_meta"]["vendor/key"] == "v"
+        @test res_dict["_meta"]["vendor/key"] == "v"
+    end
+
     @testset "Prompts list includes title and icons" begin
         icon = MCPIcon(src="data:image/png;base64,abc", sizes=["48x48"])
         prompt = MCPPrompt(
@@ -185,6 +243,7 @@ end
         @test !haskey(tool_dict, "icons")
         @test !haskey(tool_dict, "annotations")
         @test !haskey(tool_dict, "outputSchema")
+        @test !haskey(tool_dict, "_meta")
     end
 
     @testset "MCPIcon serialization" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,7 @@ const RUN_E2E = get(ENV, "MCP_TEST_E2E", ON_CI ? "false" : "true") == "true"
 
     if RUN_E2E
         include("e2e/test_protocol_e2e.jl")
+        include("e2e/test_wire_conformance.jl")
     else
         @info "Skipping E2E protocol tests (local-only; set MCP_TEST_E2E=true to run, e.g. in the nightly CI job)"
     end

--- a/test/transports/test_http.jl
+++ b/test/transports/test_http.jl
@@ -175,6 +175,9 @@
         @test result["id"] == 2
         @test result["result"]["content"][1]["text"] == "Echo: Hello MCP"
         @test result["result"]["isError"] == false
+        # Response header echoes the NEGOTIATED version (client initialized with 2025-06-18),
+        # not the transport's static default
+        @test HTTP.header(response, "MCP-Protocol-Version") == "2025-06-18"
         
         # Clean up
         server.active = false

--- a/test/utils/serialization.jl
+++ b/test/utils/serialization.jl
@@ -142,4 +142,48 @@ end
     # existing fields are unaffected
     @test haskey(j_with, "content")
     @test j_with["isError"] == false  # is_error -> isError wire key
+
+    # _meta is emitted verbatim, omitted when nothing
+    with_meta = CallToolResult(
+        content = [Dict{String,Any}("type" => "text", "text" => "hi")],
+        _meta = Dict("trace" => "abc"),
+    )
+    j_meta = JSON3.read(JSON3.write(with_meta), Dict{String,Any})
+    @test j_meta["_meta"]["trace"] == "abc"
+    @test !haskey(j_without, "_meta")
+end
+
+@testset "AudioContent conversion" begin
+    audio = AudioContent(data = [0x52, 0x49, 0x46, 0x46], mime_type = "audio/wav")
+    dict = content2dict(audio)
+    @test dict["type"] == "audio"
+    @test dict["data"] == base64encode([0x52, 0x49, 0x46, 0x46])
+    @test dict["mimeType"] == "audio/wav"
+    @test !haskey(dict, "annotations")
+    @test !haskey(dict, "_meta")
+
+    # AudioContent is a valid prompt message content type
+    msg = PromptMessage(content = audio)
+    @test msg.content isa AudioContent
+end
+
+@testset "ResourceLink spec wire format" begin
+    link = ResourceLink(
+        uri = "file:///project/result.png",
+        name = "result.png",
+        description = "Segmentation overlay",
+        mime_type = "image/png",
+    )
+    dict = content2dict(link)
+    # MCP spec shape: type "resource_link" with uri/name (not "link"/"href")
+    @test dict["type"] == "resource_link"
+    @test dict["uri"] == "file:///project/result.png"
+    @test dict["name"] == "result.png"
+    @test dict["description"] == "Segmentation overlay"
+    @test dict["mimeType"] == "image/png"
+    @test !haskey(dict, "href")
+
+    # Optional fields omitted when unset
+    minimal = content2dict(ResourceLink(uri = "file:///x", name = "x"))
+    @test !haskey(minimal, "description") && !haskey(minimal, "mimeType") && !haskey(minimal, "title")
 end


### PR DESCRIPTION
Wave-2 conformance batch toward full MCP 2025-11-25 compliance, targeted at **0.5.1** (all additive except one wire-format bugfix).

## Added
- **`AudioContent`** — third media content type (`{"type":"audio","data":...,"mimeType":...}`), valid in tool results and prompt messages (`PromptMessage` union extended).
- **`serverInfo.description`** — `mcp_server(; description=...)` (field existed, was never emitted) now appears in the initialize response; `Implementation` (clientInfo) gains optional `title`/`description` (MCP 2025-11-25).
- **`_meta`** on `MCPTool`/`MCPResource`/`MCPPrompt` (emitted verbatim in the `*/list` entries when set) and on `CallToolResult` (omitted when `nothing`).
- **JSON Schema 2020-12 dialect**: input schemas *generated from `ToolParameter` lists* declare `"$schema"`; a raw `input_schema` passes through verbatim (user controls their own dialect).

## Fixed
- **`ResourceLink` wire format** — was `{"type":"link","href":...}`, which is not in the spec; compliant clients silently ignored it. Now the spec shape `{"type":"resource_link","uri":...,"name":...,"description":...,"mimeType":...}`. Struct fields updated (`href`→`uri`, new required `name`, optional `description`/`mime_type`). Technically a field change shipped in a patch — justified because the old form **never interoperated** (zero internal usage; 0.5.0 registered hours ago). Caught via @aimg's AIMicroGraph remote-demo field feedback.
- **HTTP `MCP-Protocol-Version` response header echoes the negotiated version** after `initialize` (was a static per-transport default → mismatched header when a client negotiated down; found by the e2e harness in #40). New transport hook `set_negotiated_version!` (default no-op; `HttpTransport` updates its advertised version; single-session semantics unchanged).

## Docs
- `structuredContent` docstring now carries the spec guidance to also return a human-readable `content` fallback.

## Versioning
`Project.toml` → **0.5.1**, CHANGELOG section added. Everything is additive except the ResourceLink fix discussed above.

Suite: **568 passing** including e2e (+25 new tests: AudioContent serialization + prompt-union, ResourceLink spec shape + omissions, `_meta` emission/omission across all three component types and CallToolResult, `$schema` injection + raw-passthrough, serverInfo description emission/omission, HTTP negotiated-header echo through a real server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
