### PR TITLE
docs: refresh README, guides, and api_overview to 0.5.x reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Julia implementation of the [Model Context Protocol](https://github.com/modelc
 
 ## Overview
 
-The Model Context Protocol allows applications to provide context and capabilities to LLMs in a standardized way. This package implements the full MCP specification in Julia, with `mcp_server()` as the main entry point for creating and configuring servers.
+The Model Context Protocol allows applications to provide context and capabilities to LLMs in a standardized way. This package implements the MCP **2025-11-25** specification in Julia (negotiating down to `2024-11-05` for older clients), with `mcp_server()` as the main entry point for creating and configuring servers.
 
 The `mcp_server()` function provides a flexible interface to:
 - Create MCP servers with custom names and configurations
@@ -21,7 +21,7 @@ Example:
 ```julia
 server = mcp_server(
     name = "my-server",
-    version = "2024-11-05",
+    version = "1.0.0",            # YOUR server's version (the MCP protocol version is negotiated)
     tools = my_tool,              # Single tool or vector of tools
     resources = my_resource,      # Single resource or vector of resources
     prompts = my_prompt,          # Single prompt or vector of prompts
@@ -30,11 +30,19 @@ server = mcp_server(
 )
 ```
 
-The package enables you to:
-- Create MCP servers that expose tools, resources, and prompts
-- Define custom tools that LLMs can interact with
-- Organize and auto-register components from directory structures
-- Handle all MCP protocol messages and lifecycle events
+## Features
+
+- **Protocol 2025-11-25** with version negotiation back to `2024-11-05`
+- **Transports**: stdio (default) and Streamable HTTP with SSE and session management
+- **Content types**: text, image, audio, embedded resources, and `resource_link` references
+- **Structured tool output**: declare an `output_schema`, return `structuredContent`
+- **Tool annotations**: behavioral hints (`readOnlyHint`, `destructiveHint`, …) for client trust decisions
+- **Progress notifications**: long-running tools report progress via context-aware handlers
+- **OAuth Resource Server** (HTTP): bearer-token validation (GitHub tokens, JWT claims, RFC 7662
+  introspection) with RFC 9728 discovery metadata
+- **Logging control**: clients adjust verbosity at runtime via `logging/setLevel`; opt-in
+  per-request lifecycle logs
+- **Auto-registration** of components from a directory layout
 
 ## Core Components
 
@@ -184,6 +192,44 @@ The package will automatically scan the directory structure and register all com
 - `prompts/`: Contains prompt definitions (MCPPrompt instances)
 
 Each component file should export one or more instances of the appropriate type. They will be automatically discovered and registered with the server.
+
+### Remote Server over HTTP (with optional GitHub-token auth)
+
+```julia
+using ModelContextProtocol
+
+server = mcp_server(name = "remote-server", version = "1.0.0", tools = my_tools)
+
+# Token-gate the endpoint (optional): clients send `Authorization: Bearer <GitHub PAT>`
+auth = create_github_auth(allowed_users = ["your-github-username"])
+meta = create_github_resource_metadata("http://your-host:3000")
+
+server.transport = HttpTransport(host = "0.0.0.0", port = 3000,
+                                 auth = auth, resource_metadata = meta)
+connect(server.transport)
+start!(server)
+```
+
+Connect Claude Desktop to a remote server with `npx mcp-remote http://your-host:3000 --allow-http`.
+
+### Progress from Long-Running Tools
+
+Handlers may accept a second context argument and stream progress while they work:
+
+```julia
+slow_tool = MCPTool(
+    name = "process",
+    description = "Process a dataset with progress updates",
+    parameters = [],
+    handler = (args, ctx) -> begin
+        for i in 1:10
+            send_progress(ctx, i; total = 10, message = "step $i")  # no-op if client sent no progressToken
+            # ... do work ...
+        end
+        TextContent(text = "done")
+    end
+)
+```
 
 ## Using with Claude
 

--- a/api_overview.md
+++ b/api_overview.md
@@ -21,7 +21,7 @@
 
 ## Overview
 
-ModelContextProtocol.jl provides a Julia implementation of the Model Context Protocol (MCP) version 2025-06-18, enabling standardized communication between AI applications and external tools, resources, and data sources.
+ModelContextProtocol.jl provides a Julia implementation of the Model Context Protocol (MCP) version 2025-11-25 (negotiating per client down to 2024-11-05), enabling standardized communication between AI applications and external tools, resources, and data sources. Notable capabilities: structured tool output (`output_schema`/`structuredContent`), tool annotations, audio content and `resource_link` content blocks, progress notifications from context-aware handlers (`handler = (args, ctx) -> ...` + `send_progress`), runtime `logging/setLevel`, and an OAuth Resource Server for the HTTP transport (`create_github_auth`, `HttpTransport(; auth, resource_metadata)`).
 
 ### Version Information
 
@@ -29,7 +29,7 @@ ModelContextProtocol.jl provides a Julia implementation of the Model Context Pro
 
 | Version Type | Example | Who Sets It | Purpose |
 |-------------|---------|------------|----------|
-| **Protocol Version** | `"2025-06-18"` | MCP Specification | Protocol compatibility (fixed) |
+| **Protocol Version** | `"2025-11-25"` | MCP Specification | Negotiated per client at initialize (down to `2024-11-05`) |
 | **Server Version** | `"1.0.0"` | You (developer) | Your server's version |
 
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,14 +4,18 @@ Julia implementation of the [Model Context Protocol (MCP)](https://modelcontextp
 
 ## Features
 
-- ✅ **Core MCP 2025-06-18 Protocol** - Server-side implementation with tools, resources, and prompts
-- ✅ **Multiple Transports** - stdio (default) and HTTP with Server-Sent Events
-- ✅ **Multi-Content Responses** - Tools can return text, images, and embedded resources
-- ✅ **Auto-Registration** - Automatic component discovery from directory structure
-- ✅ **Type-Safe** - Leverages Julia's type system for robust implementations
-- ✅ **Session Management** - Secure session handling for HTTP transport
+- ✅ **MCP 2025-11-25 Protocol** - server-side implementation with version negotiation back to `2024-11-05`
+- ✅ **Multiple Transports** - stdio (default) and Streamable HTTP with Server-Sent Events and session management
+- ✅ **All Content Types** - text, images, audio, embedded resources, and `resource_link` references
+- ✅ **Structured Tool Output** - `output_schema` declarations with `structuredContent` results
+- ✅ **Tool Annotations** - behavioral hints (`readOnlyHint`, `destructiveHint`, …) for client trust decisions
+- ✅ **Progress Notifications** - long-running tools report progress through context-aware handlers
+- ✅ **OAuth Resource Server** - bearer-token validation for HTTP (GitHub tokens, JWT claims, RFC 7662 introspection) with RFC 9728 discovery
+- ✅ **Logging Control** - runtime `logging/setLevel` plus opt-in per-request lifecycle logs
+- ✅ **Auto-Registration** - automatic component discovery from directory structure
+- ✅ **Type-Safe** - leverages Julia's type system for robust implementations
 
-**Note:** This is a server-side implementation. Client features (roots, sampling), OAuth, and some optional features (elicitation, audio content) are not yet implemented.
+**Note:** This is a server-side implementation. Client features (roots, sampling), spec Tasks, elicitation, and the OAuth *Authorization Server* (token issuance) are not yet implemented.
 
 ## Installation
 
@@ -57,14 +61,15 @@ start!(server)
 For web-based integrations, use the HTTP transport:
 
 ```julia
-# Create server with HTTP transport
+# Create server, then attach an HTTP transport
 server = mcp_server(
     name = "http-server",
     version = "1.0.0",
-    tools = [...],  # Your tools here
-    transport = HttpTransport(host = "127.0.0.1", port = 3000)
+    tools = [...]  # Your tools here
 )
 
+server.transport = HttpTransport(host = "127.0.0.1", port = 3000)
+connect(server.transport)
 start!(server)
 
 # Test with curl
@@ -86,14 +91,15 @@ start!(server)
 
 ## Protocol Compliance
 
-ModelContextProtocol.jl implements the MCP specification version `2025-06-18`, including:
+ModelContextProtocol.jl implements the MCP specification version `2025-11-25` and negotiates
+with clients speaking `2025-06-18`, `2025-03-26`, or `2024-11-05`. This includes:
 
-- JSON-RPC 2.0 message protocol
-- Tool discovery and invocation
-- Resource management with subscriptions
-- Prompt templates with arguments
-- Session management for HTTP transport
-- Content negotiation and multi-format responses
+- JSON-RPC 2.0 message protocol (batching rejected per spec)
+- Tool discovery and invocation, structured output, annotations, `_meta`
+- Resource management with subscriptions and `resource_link` references
+- Prompt templates with arguments and media content
+- Progress notifications (`notifications/progress`) and logging (`logging/setLevel`)
+- Session management and OAuth Resource Server authentication for HTTP transport
 
 ## Basic Concepts
 
@@ -138,14 +144,7 @@ resource = MCPResource(
     name = "Application Config",
     description = "Current application configuration",
     mime_type = "application/json",
-    handler = function(uri)
-        config_data = read("config.json", String)
-        return TextResourceContents(
-            uri = uri,
-            text = config_data,
-            mime_type = "application/json"
-        )
-    end
+    data_provider = () -> JSON3.read(read("config.json", String), Dict{String,Any})
 )
 ```
 
@@ -164,18 +163,18 @@ prompt = MCPPrompt(
             required = true
         )
     ],
-    handler = function(args)
-        return [
-            PromptMessage(
-                role = user,
-                content = TextContent(
-                    text = "Please review this $(args["language"]) code for best practices."
-                )
+    messages = [
+        PromptMessage(
+            content = TextContent(
+                text = "Please review this {language} code for best practices."
             )
-        ]
-    end
+        )
+    ]
 )
 ```
+
+Template placeholders like `{language}` are substituted from the arguments supplied in
+`prompts/get`.
 
 ## Testing Your Server
 

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -261,3 +261,93 @@ safe_tool = MCPTool(
     end
 )
 ```
+
+## Structured Output
+
+Declare an `output_schema` and return machine-readable results in `structuredContent`
+alongside the human-readable `content` (the spec recommends providing both):
+
+```julia
+stats_tool = MCPTool(
+    name = "get_stats",
+    description = "Compute dataset statistics",
+    parameters = [],
+    output_schema = Dict{String,Any}(
+        "type" => "object",
+        "properties" => Dict{String,Any}("count" => Dict{String,Any}("type" => "integer"))
+    ),
+    handler = args -> CallToolResult(
+        content = [Dict{String,Any}("type" => "text", "text" => "{\"count\": 42}")],
+        structured_content = Dict("count" => 42)
+    )
+)
+```
+
+The schema is emitted as `outputSchema` in `tools/list`; the result field serializes as
+`structuredContent`.
+
+## Tool Annotations
+
+Annotations are behavioral hints clients can use for trust and approval decisions. They
+are emitted verbatim in `tools/list`:
+
+```julia
+MCPTool(
+    name = "delete_file",
+    description = "Delete a file",
+    parameters = [ToolParameter(name = "path", type = "string", description = "File path", required = true)],
+    handler = my_handler,
+    annotations = Dict{String,Any}(
+        "readOnlyHint" => false,
+        "destructiveHint" => true,
+        "idempotentHint" => true,
+        "openWorldHint" => false
+    )
+)
+```
+
+## Context-Aware Handlers and Progress
+
+A handler may accept a second argument to receive the per-request context — useful for
+progress reporting on long-running tools and for reading the authenticated user when
+HTTP auth is enabled:
+
+```julia
+MCPTool(
+    name = "long_job",
+    description = "Process with progress updates",
+    parameters = [],
+    handler = (args, ctx) -> begin
+        for i in 1:10
+            send_progress(ctx, i; total = 10, message = "step $i")
+            # ... work ...
+        end
+        TextContent(text = "done")
+    end
+)
+```
+
+`send_progress` emits `notifications/progress` (over stdout for stdio, over the SSE
+stream for HTTP) and is a safe no-op when the client did not send a `progressToken`.
+The context also exposes `ctx.authenticated_user` and `ctx.request_id`. Plain
+one-argument handlers keep working unchanged.
+
+## Audio and Resource Links in Results
+
+Tools can return audio and references to large artifacts without embedding them:
+
+```julia
+handler = args -> [
+    TextContent(text = "Analysis complete"),
+    AudioContent(data = wav_bytes, mime_type = "audio/wav"),
+    ResourceLink(
+        uri = "file:///results/overlay.png",
+        name = "overlay.png",
+        mime_type = "image/png",
+        size = 123_456
+    )
+]
+```
+
+`ResourceLink` serializes to the spec `resource_link` content block, letting clients fetch
+or subscribe to the artifact instead of receiving inline base64.

--- a/docs/src/transports.md
+++ b/docs/src/transports.md
@@ -34,11 +34,11 @@ The Streamable HTTP transport implements the MCP protocol over HTTP with Server-
 using ModelContextProtocol
 using ModelContextProtocol: HttpTransport
 
-# Create HTTP transport
+# Create HTTP transport (the MCP protocol version is negotiated per client;
+# the server speaks 2025-11-25 down to 2024-11-05)
 transport = HttpTransport(
     host = "127.0.0.1",
-    port = 3000,
-    protocol_version = "2025-06-18"
+    port = 3000
 )
 
 # Create server
@@ -63,12 +63,16 @@ transport = HttpTransport(
     host = "127.0.0.1",           # Bind address (localhost by default)
     port = 3000,                  # Port number
     endpoint = "/",               # Base endpoint path
-    protocol_version = "2025-06-18",  # MCP protocol version
     session_required = true,      # Require session validation
     allowed_origins = ["http://localhost:8080"],  # CORS origins
-    enable_sse = true            # Enable Server-Sent Events
+    auth = nothing,               # Optional AuthMiddleware (see Authentication below)
+    resource_metadata = nothing   # Optional RFC 9728 Protected Resource Metadata
 )
 ```
+
+The advertised MCP protocol version defaults to the latest supported (`2025-11-25`) and is
+negotiated per client during `initialize`; response headers echo the negotiated version.
+SSE is always available via `GET` with `Accept: text/event-stream` — there is no switch.
 
 ### Session Management
 
@@ -96,20 +100,46 @@ curl -X POST http://localhost:3000/ \
 
 ### Server-Sent Events (SSE)
 
-The HTTP transport supports real-time streaming via Server-Sent Events:
+The HTTP transport streams server-to-client notifications via Server-Sent Events. Clients
+open the stream with a `GET` request:
 
-```julia
-# SSE is enabled by default in HttpTransport
-transport = HttpTransport(enable_sse = true)
+```bash
+curl -N -H 'Accept: text/event-stream' http://127.0.0.1:3000/
 ```
 
-SSE streams provide:
-- Real-time notifications to clients
-- Progress updates for long-running operations  
-- Event-based communication patterns
-- Automatic reconnection support
+SSE streams carry:
+- Server notifications (`notifications/message` log events)
+- Progress updates for long-running tool calls (`notifications/progress`)
+- Responses, when the client requested SSE delivery
 
 ### Security Features
+
+#### Authentication (OAuth Resource Server)
+
+The HTTP transport can require a bearer token on every request. Validators include GitHub
+tokens (validated against the GitHub API with optional allowlist/organization checks),
+JWT claims, and RFC 7662 token introspection:
+
+```julia
+using ModelContextProtocol
+
+auth = create_github_auth(
+    allowed_users = ["alice", "bob"],   # empty list = any authenticated GitHub user
+    required_org  = "MyLab",            # optional organization gate
+)
+meta = create_github_resource_metadata("https://mcp.example.org")
+
+transport = HttpTransport(host = "0.0.0.0", port = 3000,
+                          auth = auth, resource_metadata = meta)
+```
+
+Clients send `Authorization: Bearer <token>`; unauthorized requests get `401`/`403` with an
+RFC 6750 `WWW-Authenticate` header, and discovery metadata is served at
+`/.well-known/oauth-protected-resource` (RFC 9728). Tool handlers can read the verified
+identity by accepting the request context: `handler = (args, ctx) -> ...` and using
+`ctx.authenticated_user`. Note: `JWTValidator` checks claims only (no JWKS signature
+verification yet); prefer the GitHub or introspection validators when tokens must be
+verified against an authority.
 
 #### Origin Validation
 
@@ -174,9 +204,10 @@ using Sockets
 
 #### Protocol Version Mismatches
 
-- Use `MCP-Protocol-Version: 2025-06-18` header in all requests
+- The server accepts any supported version (`2025-11-25`, `2025-06-18`, `2025-03-26`,
+  `2024-11-05`) in the `MCP-Protocol-Version` header and negotiates during `initialize`
+- Response headers echo the **negotiated** version after initialization
 - Check server logs for protocol version negotiation messages
-- Ensure client and server support the same protocol version
 
 ### Migration from stdio
 
@@ -204,6 +235,5 @@ Key changes:
 ### Examples
 
 See the `examples/` directory for complete working examples:
-- `examples/streamable_http_basic.jl` - Simple HTTP server setup
-- `examples/streamable_http_demo.jl` - Full-featured server with SSE
-- `examples/streamable_http_advanced.jl` - Advanced configuration and usage
+- `examples/simple_http_server.jl` - Simple HTTP server setup
+- `examples/reg_dir_http.jl` - HTTP server with directory auto-registration


### PR DESCRIPTION
Third piece of **0.5.2**: user-facing docs lagged 2–3 releases. Beyond freshness, this fixes **examples that never worked**:

## Broken examples fixed
- `index.md`: `MCPResource(handler=…)` → the real kwarg is `data_provider`; `MCPPrompt(handler=…)` → prompts take `messages` templates (placeholder substitution documented); `mcp_server(transport=…)` → not a kwarg (set `server.transport`, then `connect`).
- `README`: quick-start modeled `version = "2024-11-05"` as the **server** version — the exact protocol/server confusion 0.3.0 was released to eliminate.
- `transports.md`: documented a nonexistent `enable_sse` kwarg and three example files that don't exist; hardcoded `protocol_version = "2025-06-18"` (now negotiated, headers echo it).

## Refreshed/added
- **Features** sections (README + index.md) covering 0.4–0.5.2: negotiation, audio, structured output, annotations, progress, OAuth RS, `logging/setLevel`
- **Authentication section** in transports.md with the GitHub-validator recipe (`create_github_auth` + `resource_metadata` + ctx access to the identity) and the JWT claims-only caveat
- **tools.md**: structured output, tool annotations, context-aware handlers + `send_progress`, audio + `resource_link` results
- **api_overview.md** (the AI-parseable root reference): header brought to 2025-11-25 + capability summary
- Accurate protocol statements everywhere (2025-11-25, negotiated to 2024-11-05)

Docs build green locally (same 3 pre-existing docstring warnings as main). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
