### PR TITLE
Serve ResourceContents from data_provider — binary resources (0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Binary and rich resource contents** (closes #59): `resources/read` now serializes
+  `TextResourceContents`/`BlobResourceContents` (or a vector of them) returned from a
+  resource's `data_provider` directly to the spec wire shape — `BlobResourceContents`
+  makes binary resources servable for the first time (base64 `blob` contents entry,
+  per-entry `uri`/`mimeType`). Plain data keeps the JSON-encoded text fallback. This
+  pairs with `ResourceLink` tool results: link to a large artifact, read the binary
+  via `resources/read`.
+
+### Fixed
+
+- A `String` returned from a `data_provider` is now used as the text contents verbatim
+  instead of arriving JSON-quoted (`"\"…\""`).
+
 ## [0.5.3] - 2026-06-10
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelContextProtocol"
 uuid = "c58f755f-f2a7-4f48-bf29-4e9659b78499"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["klidke@unm.edu"]
 
 [deps]

--- a/api_overview.md
+++ b/api_overview.md
@@ -556,12 +556,29 @@ MCPResource(;
     name::String,                         # Human-readable name
     description::String = "",             # Description
     mime_type::String = "application/json", # MIME type
-    data_provider::Function,              # () -> data function
+    data_provider::Function,              # () -> data function (see note below)
     annotations::AbstractDict = LittleDict{String,Any}()  # Metadata (uses LittleDict for performance)
 )
 ```
 
 **Note:** The `uri` is stored internally as a `URI` object but accepts strings for convenience.
+
+**Provider return values** (`resources/read` contents):
+- `TextResourceContents` / `BlobResourceContents` (or a `Vector` of them): serialized
+  directly — `BlobResourceContents` is how binary resources are served (base64 `blob`)
+- `String`: used as the text verbatim with the resource's `mime_type`
+- anything else: JSON-encoded into a text contents entry
+
+```julia
+# Binary resource
+logo = MCPResource(
+    uri = "images://logo",
+    name = "Logo",
+    mime_type = "image/png",
+    data_provider = () -> BlobResourceContents(
+        uri = "images://logo", mime_type = "image/png", blob = read("logo.png"))
+)
+```
 
 #### `ResourceTemplate`
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -137,7 +137,8 @@ using ModelContextProtocol
 using URIs  # For URI construction
 
 # Create a resource with a custom data provider
-# (called with no arguments; the return value is JSON-encoded into the contents)
+# (called with no arguments; plain data is JSON-encoded — return a String for
+# verbatim text or Text/BlobResourceContents for full control incl. binary)
 config_resource = MCPResource(
     uri = URI("config://app/settings"),
     name = "Application Settings",

--- a/docs/src/resources.md
+++ b/docs/src/resources.md
@@ -110,10 +110,17 @@ server = mcp_server(
 
 ### Resource with Dynamic Data
 
-The `data_provider` is called with no arguments on every `resources/read`, and its
-return value is JSON-encoded into the resource contents:
+The `data_provider` is called with no arguments on every `resources/read`. What it
+returns determines the wire contents:
+
+- A **`TextResourceContents`** or **`BlobResourceContents`** (or a vector of them) is
+  serialized directly — this is how binary resources are served (base64 `blob` on the
+  wire) and how you control the contents `uri`/`mimeType` per entry.
+- A **`String`** becomes the text contents verbatim, with the resource's `mime_type`.
+- Anything else is **JSON-encoded** into a text contents entry.
 
 ```julia
+# JSON data (encoded automatically)
 log_resource = MCPResource(
     uri = "app://logs/recent",
     name = "Recent Log Entries",
@@ -127,13 +134,28 @@ log_resource = MCPResource(
 )
 ```
 
+### Resource with Binary Data
+
+Return a `BlobResourceContents` to serve binary data (base64-encoded on the wire):
+
+```julia
+image_resource = MCPResource(
+    uri = "images://logo",
+    name = "Logo Image",
+    description = "Company logo",
+    mime_type = "image/png",
+    data_provider = () -> BlobResourceContents(
+        uri = "images://logo",
+        mime_type = "image/png",
+        blob = read("logo.png")   # Vector{UInt8}
+    )
+)
+```
+
+This pairs naturally with `ResourceLink` tool results: a tool can return a link to a
+large artifact, and the client then reads the binary via `resources/read`.
+
 ### Current Limitations
 
 - Resources are matched by **exact URI**; wildcard or template URIs (e.g. `file://*`)
-  are not routed to providers.
-- The read path always JSON-encodes the provider's return value into a text contents
-  entry with the resource's declared `mime_type`. Returning `TextResourceContents` or
-  `BlobResourceContents` directly is not yet supported, so binary resources cannot be
-  served via `resources/read` today.
-- To deliver binary data, use a tool that returns `ImageContent`/`AudioContent` or an
-  `EmbeddedResource` instead.
+  are not routed to providers (`data_provider` takes no arguments).

--- a/docs/src/resources.md
+++ b/docs/src/resources.md
@@ -37,17 +37,19 @@ Note: The `uri` field accepts both strings and URI objects. Strings are automati
 
 ## Data Providers
 
-The `data_provider` function can return different types of data:
+The `data_provider` is a **zero-argument** function called on every `resources/read`.
+It can return different types of data:
 
 1. **For simple data (automatically serialized to JSON)**:
    - Return Julia objects (Dict, Array, etc.) that can be JSON-serialized
-   - These are wrapped in `TextResourceContents` with JSON serialization
+   - These become a text contents entry with the resource's `mime_type`
 
-2. **For explicit control over content**:
+2. **For verbatim text**: return a `String` — used as the text contents as-is
+
+3. **For explicit control over content** (including binary):
    - Return `TextResourceContents` for text data
-   - Return `BlobResourceContents` for binary data
-   
-The `data_provider` receives the requested URI as a parameter when using wildcards.
+   - Return `BlobResourceContents` for binary data (base64 `blob` on the wire)
+   - Return a `Vector` of them for multiple contents entries
 
 ## Registering Resources
 

--- a/examples/CLAUDE.md
+++ b/examples/CLAUDE.md
@@ -105,8 +105,9 @@ hello_tool = MCPTool(
     end
 )
 
-# Define a resource (data_provider takes no arguments; its return value
-# is JSON-encoded into the resource contents)
+# Define a resource (data_provider takes no arguments; plain data is JSON-encoded,
+# a String is used verbatim, and Text/BlobResourceContents serialize directly —
+# BlobResourceContents is how binary resources are served)
 data_resource = MCPResource(
     uri = "example://data",
     name = "Example Data",

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -105,26 +105,27 @@ Base.@kwdef struct HandlerResult
 end
 
 """
-    serialize_resource_contents(resource::ResourceContents) -> Dict{String,Any}
+    serialize_resource_contents(resource::ResourceContents) -> LittleDict{String,Any}
 
-Serialize resource contents to protocol format.
+Serialize resource contents to the spec wire shape: `{uri, text, mimeType}` for
+`TextResourceContents`, `{uri, blob, mimeType}` (base64) for `BlobResourceContents`.
 
 # Arguments
 - `resource::ResourceContents`: The resource contents to serialize
 
 # Returns
-- `Dict{String,Any}`: The serialized resource contents
+- `LittleDict{String,Any}`: The serialized resource contents entry
 """
 function serialize_resource_contents(resource::ResourceContents)
     if resource isa TextResourceContents
         LittleDict{String,Any}(
-            "uri" => resource.uri,
+            "uri" => string(resource.uri),
             "text" => resource.text,
             "mimeType" => resource.mime_type
         )
     elseif resource isa BlobResourceContents
         LittleDict{String,Any}(
-            "uri" => resource.uri,
+            "uri" => string(resource.uri),
             "blob" => base64encode(resource.blob),
             "mimeType" => resource.mime_type
         )
@@ -604,12 +605,24 @@ function handle_read_resource(ctx::RequestContext, params::ReadResourceParams)::
 
     try
         data = resource.data_provider()
-        
-        contents = [LittleDict{String,Any}(
-            "uri" => string(resource.uri),
-            "text" => JSON3.write(data),
-            "mimeType" => resource.mime_type
-        )]
+
+        # Normalize the provider's return value into spec contents entries:
+        # - ResourceContents (or a vector of them) serialize directly — the only
+        #   path that can produce binary `blob` contents
+        # - a String becomes the text verbatim (with the resource's mime type)
+        # - anything else keeps the JSON-encoded fallback
+        contents = if data isa ResourceContents
+            [serialize_resource_contents(data)]
+        elseif data isa Vector{<:ResourceContents} ||
+               (data isa Vector && !isempty(data) && all(x -> x isa ResourceContents, data))
+            [serialize_resource_contents(x) for x in data]
+        else
+            [LittleDict{String,Any}(
+                "uri" => string(resource.uri),
+                "text" => data isa AbstractString ? String(data) : JSON3.write(data),
+                "mimeType" => resource.mime_type
+            )]
+        end
 
         # Use the proper ReadResourceResult struct
         HandlerResult(

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -607,14 +607,17 @@ function handle_read_resource(ctx::RequestContext, params::ReadResourceParams)::
         data = resource.data_provider()
 
         # Normalize the provider's return value into spec contents entries:
-        # - ResourceContents (or a vector of them) serialize directly — the only
-        #   path that can produce binary `blob` contents
+        # - TextResourceContents/BlobResourceContents (or a vector of them)
+        #   serialize directly — the only path that can produce binary `blob`
+        #   contents. Dispatch is on the two concrete spec types, so a custom
+        #   ResourceContents subtype falls through to the JSON fallback instead
+        #   of erroring inside serialize_resource_contents.
         # - a String becomes the text verbatim (with the resource's mime type)
         # - anything else keeps the JSON-encoded fallback
-        contents = if data isa ResourceContents
+        wire_contents = Union{TextResourceContents,BlobResourceContents}
+        contents = if data isa wire_contents
             [serialize_resource_contents(data)]
-        elseif data isa Vector{<:ResourceContents} ||
-               (data isa Vector && !isempty(data) && all(x -> x isa ResourceContents, data))
+        elseif data isa Vector && !isempty(data) && all(x -> x isa wire_contents, data)
             [serialize_resource_contents(x) for x in data]
         else
             [LittleDict{String,Any}(

--- a/src/types.jl
+++ b/src/types.jl
@@ -527,7 +527,11 @@ Resources represent data that can be read by models and tools.
 - `name::String`: Human-readable name for the resource
 - `description::String`: Detailed description of the resource
 - `mime_type::String`: MIME type of the resource data
-- `data_provider::Function`: Function that provides the resource data when called
+- `data_provider::Function`: Zero-argument function returning the resource data for
+  `resources/read`. Return a `TextResourceContents`/`BlobResourceContents` (or a vector
+  of them) for full control — `BlobResourceContents` is how binary resources are served
+  (base64 `blob` on the wire). A `String` is used as the text verbatim; any other value
+  is JSON-encoded into a text contents entry with the resource's `mime_type`.
 - `annotations::AbstractDict{String,Any}`: Additional metadata for the resource
 """
 struct MCPResource <: Resource
@@ -556,7 +560,9 @@ Create a resource with automatic URI conversion from strings or URIs.
 - `name::String`: Human-readable name for the resource
 - `description::String`: Detailed description
 - `mime_type::String`: MIME type of the resource
-- `data_provider::Function`: Function that returns the resource data when called
+- `data_provider::Function`: Zero-argument function returning the resource data
+  (`ResourceContents`/vector for full control incl. binary `blob`; `String` verbatim;
+  anything else JSON-encoded — see `MCPResource` field docs)
 - `annotations::AbstractDict{String,Any}`: Additional metadata for the resource
 - `title::Union{String,Nothing}`: Optional human-friendly display name
 - `icons::Union{Vector{MCPIcon},Nothing}`: Optional icons for UI display

--- a/test/e2e/fixtures/wire_demo_server.jl
+++ b/test/e2e/fixtures/wire_demo_server.jl
@@ -75,13 +75,30 @@ res = MCPResource(
     _meta = Dict{String,Any}("lab/resource" => 1),
 )
 
+res_blob = MCPResource(
+    uri = "demo://logo",
+    name = "logo",
+    description = "Binary resource (BlobResourceContents demo)",
+    mime_type = "image/png",
+    data_provider = () -> BlobResourceContents(
+        uri = "demo://logo", mime_type = "image/png", blob = png_bytes),
+)
+
+res_text = MCPResource(
+    uri = "demo://readme",
+    name = "readme",
+    description = "Verbatim String resource demo",
+    mime_type = "text/plain",
+    data_provider = () -> "plain, not JSON-quoted",
+)
+
 server = mcp_server(
     name = "wire-demo",
     version = "0.1.0",
     description = "Wire conformance demo server",
     tools = [analyze, structured, count_slow],
     prompts = [media_prompt],
-    resources = [res],
+    resources = [res, res_blob, res_text],
 )
 
 if "http" in ARGS

--- a/test/e2e/test_wire_conformance.jl
+++ b/test/e2e/test_wire_conformance.jl
@@ -18,9 +18,11 @@ const _WIRE_REQUESTS = [
     """{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_stats","arguments":{}},"id":4}""",
     """{"jsonrpc":"2.0","method":"prompts/get","params":{"name":"media_demo"},"id":5}""",
     """{"jsonrpc":"2.0","method":"resources/list","params":{},"id":6}""",
+    """{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"demo://logo"},"id":7}""",
+    """{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"demo://readme"},"id":8}""",
 ]
 
-# Shared assertions on the six responses (Dict id => parsed JSON3 object),
+# Shared assertions on the eight responses (Dict id => parsed JSON3 object),
 # used by both the stdio and HTTP passes.
 function _wire_assert(resp)
     # 1: initialize — negotiated version + serverInfo.description
@@ -65,6 +67,17 @@ function _wire_assert(resp)
 
     # 6: resources/list — _meta emitted
     @test resp[6].result.resources[1]._meta["lab/resource"] == 1
+
+    # 7: binary resource served as base64 blob contents (BlobResourceContents return)
+    blob_c = resp[7].result.contents[1]
+    @test blob_c.uri == "demo://logo"
+    @test blob_c.blob == base64encode(UInt8[0x89, 0x50, 0x4E, 0x47])
+    @test blob_c.mimeType == "image/png"
+    @test !haskey(blob_c, :text)
+
+    # 8: String provider data is the text verbatim (not JSON-quoted)
+    @test resp[8].result.contents[1].text == "plain, not JSON-quoted"
+    @test resp[8].result.contents[1].mimeType == "text/plain"
 end
 
 @testset "E2E wire conformance (real subprocesses)" begin
@@ -80,8 +93,8 @@ end
             msg = JSON3.read(line)
             haskey(msg, :id) && (resp[msg.id] = msg)
         end
-        @test length(resp) == 6
-        length(resp) == 6 && _wire_assert(resp)
+        @test length(resp) == 8
+        length(resp) == 8 && _wire_assert(resp)
     end
 
     @testset "stdio logging/setLevel takes effect live" begin
@@ -146,8 +159,8 @@ end
                     # The response HEADER echoes the NEGOTIATED version on every
                     # response (client asked 2025-06-18; transport default is latest)
                     @test all(==("2025-06-18"), versions)
-                    @test length(resp) == 6
-                    length(resp) == 6 && _wire_assert(resp)
+                    @test length(resp) == 8
+                    length(resp) == 8 && _wire_assert(resp)
                 end
             finally
                 kill(proc)

--- a/test/features/resources.jl
+++ b/test/features/resources.jl
@@ -17,6 +17,74 @@
         @test JSON3.read(contents["text"])["threshold"] == 42
     end
 
+    @testset "resources/read serves ResourceContents returns directly" begin
+        png = UInt8[0x89, 0x50, 0x4E, 0x47]
+        text_res = MCPResource(
+            uri = "test://report",
+            name = "report",
+            mime_type = "text/markdown",
+            data_provider = () -> TextResourceContents(
+                uri = "test://report",
+                mime_type = "text/markdown",
+                text = "# Report\nplain text, not JSON",
+            ),
+        )
+        blob_res = MCPResource(
+            uri = "test://logo",
+            name = "logo",
+            mime_type = "image/png",
+            data_provider = () -> BlobResourceContents(
+                uri = "test://logo",
+                mime_type = "image/png",
+                blob = png,
+            ),
+        )
+        multi_res = MCPResource(
+            uri = "test://bundle",
+            name = "bundle",
+            data_provider = () -> [
+                TextResourceContents(uri = "test://bundle/readme", text = "readme"),
+                BlobResourceContents(uri = "test://bundle/raw", mime_type = "image/png", blob = png),
+            ],
+        )
+        server = mcp_server(name = "test", version = "1.0.0",
+                            resources = [text_res, blob_res, multi_res])
+        ctx = RequestContext(server = server, request_id = 1)
+
+        # TextResourceContents: text verbatim (NOT JSON-quoted), struct's uri/mimeType
+        c = handle_read_resource(ctx, ReadResourceParams(uri = "test://report")).response.result.contents[1]
+        @test c["text"] == "# Report\nplain text, not JSON"
+        @test c["mimeType"] == "text/markdown"
+        @test c["uri"] == "test://report"
+        @test !haskey(c, "blob")
+
+        # BlobResourceContents: base64 blob, no text key — binary resources now servable
+        c = handle_read_resource(ctx, ReadResourceParams(uri = "test://logo")).response.result.contents[1]
+        @test c["blob"] == base64encode(png)
+        @test c["mimeType"] == "image/png"
+        @test !haskey(c, "text")
+
+        # Vector of contents: one entry each, order preserved, per-entry uri
+        cs = handle_read_resource(ctx, ReadResourceParams(uri = "test://bundle")).response.result.contents
+        @test length(cs) == 2
+        @test cs[1]["text"] == "readme" && cs[1]["uri"] == "test://bundle/readme"
+        @test cs[2]["blob"] == base64encode(png) && cs[2]["uri"] == "test://bundle/raw"
+    end
+
+    @testset "resources/read String returns are verbatim text" begin
+        plain = MCPResource(
+            uri = "test://motd",
+            name = "motd",
+            mime_type = "text/plain",
+            data_provider = () -> "hello, world",
+        )
+        server = mcp_server(name = "test", version = "1.0.0", resources = [plain])
+        ctx = RequestContext(server = server, request_id = 1)
+        c = handle_read_resource(ctx, ReadResourceParams(uri = "test://motd")).response.result.contents[1]
+        @test c["text"] == "hello, world"        # not "\"hello, world\""
+        @test c["mimeType"] == "text/plain"
+    end
+
     @testset "resources/read unknown URI is a resource error" begin
         server = mcp_server(name = "test", version = "1.0.0")
         ctx = RequestContext(server = server, request_id = 1)

--- a/test/features/resources.jl
+++ b/test/features/resources.jl
@@ -71,6 +71,25 @@
         @test cs[2]["blob"] == base64encode(png) && cs[2]["uri"] == "test://bundle/raw"
     end
 
+    @testset "resources/read edge returns keep the JSON fallback" begin
+        # custom ResourceContents subtypes are not wire types: JSON fallback, not an error
+        struct _FakeContents <: ModelContextProtocol.ResourceContents end
+        custom = MCPResource(uri = "test://custom", name = "custom",
+                             data_provider = () -> _FakeContents())
+        # empty vectors carry no usable contents: JSON fallback ("[]")
+        empty_v = MCPResource(uri = "test://empty", name = "empty",
+                              data_provider = () -> TextResourceContents[])
+        server = mcp_server(name = "test", version = "1.0.0", resources = [custom, empty_v])
+        ctx = RequestContext(server = server, request_id = 1)
+
+        r1 = handle_read_resource(ctx, ReadResourceParams(uri = "test://custom"))
+        @test isnothing(r1.error)
+        @test haskey(r1.response.result.contents[1], "text")
+
+        r2 = handle_read_resource(ctx, ReadResourceParams(uri = "test://empty"))
+        @test r2.response.result.contents[1]["text"] == "[]"
+    end
+
     @testset "resources/read String returns are verbatim text" begin
         plain = MCPResource(
             uri = "test://motd",


### PR DESCRIPTION
Closes #59 — the gap found by the docs-correctness audit: `resources/read` JSON-encoded every provider return into a text entry, so binary resources were impossible and `ResourceContents` returns double-encoded.

## Behavior (`resources/read`)

| `data_provider()` returns | Wire contents |
|---|---|
| `TextResourceContents` / `BlobResourceContents` (or `Vector` of them) | Serialized directly — `{uri, text\|blob (base64), mimeType}` per entry, **binary now servable** |
| `String` | Text **verbatim** with the resource's `mime_type` (was JSON-quoted) |
| anything else | JSON-encoded text fallback (unchanged) |

Implementation note: the wire-correct `serialize_resource_contents` helper already existed with **zero callers** — this wires it up (and fixes its latent bug of emitting a `URI` struct instead of a string in the `uri` field).

## Why now

Second half of the aimg use case: a tool returns a `ResourceLink` to a large artifact instead of inline base64 — useful only if the client can then read the binary resource it points to.

## Verification

- Suite **826/826** (was 800): new unit coverage for struct/blob/vector/String returns + Dict-fallback regression
- Wire-conformance e2e extended over **both transports**: base64 `blob` shape with per-entry `uri`/`mimeType` and no `text` key; `String` verbatim (not JSON-quoted)
- Local Documenter build green

## Compatibility

Additive (`0.5.4`). One deliberate behavior change called out in the CHANGELOG: `String` returns lose their spurious JSON quotes — previously `text` arrived as `\"hello\"`, which no client could have wanted; no test or example relied on it.

## Docs

resources guide (binary example restored — this time backed by a working implementation), api_overview provider-contract section, MCPResource docstrings, examples comments, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)