### PR TITLE
Resource URI templates: routed reads + resources/templates/list (0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Resource URI templates** (closes #63): `ResourceTemplate` now carries a
+  `data_provider`, and a `resources/read` whose URI matches no exact resource is routed
+  through the registered templates (RFC 6570 level-1 `{var}` placeholders, one path
+  segment each). The provider receives the requested URI — `provider(uri)` — or opts
+  into `provider(uri, vars)` for the extracted placeholder values; return values follow
+  the same contract as resource providers. Templates are advertised via the spec's
+  `resources/templates/list`, registered through `mcp_server(resource_templates=…)` or
+  `register!(server, template)`. Exact-URI resources take precedence. Requested by the
+  aimg downstream for content-addressed artifact namespaces.
 - **Binary and rich resource contents** (closes #59): `resources/read` now serializes
   `TextResourceContents`/`BlobResourceContents` (or a vector of them) returned from a
   resource's `data_provider` directly to the spec wire shape — `BlobResourceContents`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,6 +473,9 @@ negotiated version per session).
   RFC 7662 introspection, GitHub tokens + allowlist/org), RFC 9728 Protected Resource
   Metadata at `/.well-known/oauth-protected-resource`, per-request auth context.
   NOTE: `JWTValidator` validates claims only — no JWKS signature verification yet
+- **Resources**: exact-URI reads with rich provider returns (`ResourceContents`/vector
+  incl. binary `blob`, `String` verbatim, JSON fallback); **URI templates** (RFC 6570
+  level-1 `{var}`) with `resources/templates/list` + read routing to template providers
 - **Auto-registration** of components from directories
 
 ### ❌ Not Yet Implemented

--- a/api_overview.md
+++ b/api_overview.md
@@ -569,6 +569,23 @@ MCPResource(;
 - `String`: used as the text verbatim with the resource's `mime_type`
 - anything else: JSON-encoded into a text contents entry
 
+**URI templates** (`ResourceTemplate`): parameterized resource families. RFC 6570
+level-1 `{var}` placeholders (one path segment each); advertised via
+`resources/templates/list`; a `resources/read` with no exact-URI match routes to the
+first matching template's provider — `provider(uri)` or `provider(uri, vars)` for the
+extracted placeholders, same return contract as above. Register via
+`mcp_server(resource_templates = [...])` or `register!(server, template)`.
+
+```julia
+tmpl = ResourceTemplate(
+    name = "artifact",
+    uri_template = "app://artifact/{id}",
+    mime_type = "image/png",
+    data_provider = (uri, vars) -> BlobResourceContents(
+        uri = uri, mime_type = "image/png", blob = load_artifact(vars["id"]))
+)
+```
+
 ```julia
 # Binary resource
 logo = MCPResource(

--- a/docs/src/resources.md
+++ b/docs/src/resources.md
@@ -157,7 +157,35 @@ image_resource = MCPResource(
 This pairs naturally with `ResourceLink` tool results: a tool can return a link to a
 large artifact, and the client then reads the binary via `resources/read`.
 
-### Current Limitations
+## URI Templates
 
-- Resources are matched by **exact URI**; wildcard or template URIs (e.g. `file://*`)
-  are not routed to providers (`data_provider` takes no arguments).
+For a parameterized *family* of resources — content-addressed artifacts, per-id
+results, file trees — register a `ResourceTemplate` instead of one resource per URI.
+Templates use RFC 6570 level-1 placeholders (`{var}`, matching one path segment) and
+are advertised to clients via `resources/templates/list`:
+
+```julia
+artifact_template = ResourceTemplate(
+    name = "artifact",
+    uri_template = "app://artifact/{id}",
+    description = "Content-addressed result artifacts",
+    mime_type = "image/png",
+    data_provider = (uri, vars) -> BlobResourceContents(
+        uri = uri,
+        mime_type = "image/png",
+        blob = read(artifact_path(vars["id"]))
+    )
+)
+
+server = mcp_server(
+    name = "my-server",
+    resource_templates = [artifact_template]   # or register!(server, artifact_template)
+)
+```
+
+A `resources/read` whose URI matches no exact resource is routed through the
+templates: the first match with a provider serves it. The provider receives the
+requested URI — `provider(uri)` — or opts into `provider(uri, vars)` to also get the
+extracted placeholder values. Return values follow the same contract as resource
+providers (`ResourceContents`/vector, `String` verbatim, JSON fallback). Exact-URI
+resources always take precedence over templates.

--- a/src/core/init.jl
+++ b/src/core/init.jl
@@ -186,6 +186,8 @@ Primary entry point for creating and configuring a Model Context Protocol (MCP) 
 - `version::String`: Your server implementation version (defaults to "1.0.0") - YOUR server's version, not the MCP protocol version
 - `tools`: Tools to expose to the model
 - `resources`: Resources available to the model
+- `resource_templates`: Parameterized resource families (RFC 6570 `{var}` URI templates
+  with a provider; advertised via `resources/templates/list`)
 - `prompts`: Predefined prompts for the model
 - `description::String`: Optional server description
 - `capabilities::Vector{Capability}`: Server capability configuration
@@ -218,6 +220,7 @@ function mcp_server(;
     version::String = "1.0.0",
     tools::Union{Vector{MCPTool}, MCPTool, Nothing} = nothing,
     resources::Union{Vector{MCPResource}, MCPResource, Nothing} = nothing,
+    resource_templates::Union{Vector{ResourceTemplate}, ResourceTemplate, Nothing} = nothing,
     prompts::Union{Vector{MCPPrompt}, MCPPrompt, Nothing} = nothing,
     description::String = "",
     capabilities::Vector{Capability} = default_capabilities(),
@@ -246,6 +249,12 @@ function mcp_server(;
     # Register resources if provided
     if !isnothing(resources)
         foreach(r -> register!(server, r), resources isa Vector ? resources : [resources])
+    end
+
+    # Register resource templates if provided
+    if !isnothing(resource_templates)
+        foreach(t -> register!(server, t),
+                resource_templates isa Vector ? resource_templates : [resource_templates])
     end
     
     # Register prompts if provided

--- a/src/core/server.jl
+++ b/src/core/server.jl
@@ -30,6 +30,11 @@ function register!(server::Server, prompt::MCPPrompt)
     server
 end
 
+function register!(server::Server, template::ResourceTemplate)
+    push!(server.resource_templates, template)
+    server
+end
+
 """
     process_message(server::Server, state::ServerState, message::String) -> Union{String,Nothing}
 

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -135,6 +135,58 @@ function serialize_resource_contents(resource::ResourceContents)
 end
 
 """
+    normalize_read_contents(data, fallback_uri::String, fallback_mime::String)
+        -> Vector{LittleDict{String,Any}}
+
+Normalize a resource provider's return value into spec `resources/read` contents
+entries: `TextResourceContents`/`BlobResourceContents` (or a vector of them) serialize
+directly — the only path that can produce binary `blob` contents; a `String` becomes
+the text verbatim; anything else (including custom `ResourceContents` subtypes) is
+JSON-encoded into a text entry carrying `fallback_uri`/`fallback_mime`.
+"""
+function normalize_read_contents(data, fallback_uri::String, fallback_mime::String)
+    wire_contents = Union{TextResourceContents,BlobResourceContents}
+    if data isa wire_contents
+        [serialize_resource_contents(data)]
+    elseif data isa Vector && !isempty(data) && all(x -> x isa wire_contents, data)
+        [serialize_resource_contents(x) for x in data]
+    else
+        [LittleDict{String,Any}(
+            "uri" => fallback_uri,
+            "text" => data isa AbstractString ? String(data) : JSON3.write(data),
+            "mimeType" => fallback_mime
+        )]
+    end
+end
+
+_regex_escape(s::AbstractString) =
+    replace(s, r"([\\^\$\.\|\?\*\+\(\)\[\]\{\}])" => s"\\\1")
+
+"""
+    match_uri_template(template::String, uri::String) -> Union{Nothing,Dict{String,String}}
+
+Match `uri` against an RFC 6570 level-1 URI template. Each `{var}` placeholder matches
+one path segment (one or more characters excluding `/`). Returns the extracted
+variables on a full match, `nothing` otherwise.
+"""
+function match_uri_template(template::String, uri::String)::Union{Nothing,Dict{String,String}}
+    names = String[]
+    pattern = IOBuffer()
+    print(pattern, "^")
+    pos = 1
+    for m in eachmatch(r"\{([A-Za-z0-9_]+)\}", template)
+        print(pattern, _regex_escape(template[pos:prevind(template, m.offset)]))
+        push!(names, String(m.captures[1]))
+        print(pattern, "([^/]+)")
+        pos = m.offset + ncodeunits(m.match)
+    end
+    print(pattern, _regex_escape(template[pos:end]), "\$")
+    mm = match(Regex(String(take!(pattern))), uri)
+    mm === nothing && return nothing
+    Dict{String,String}(n => String(c) for (n, c) in zip(names, mm.captures))
+end
+
+"""
     convert_to_content_type(result::Any) -> Any
 
 Apply the documented convenience conversions for tool handler return values:
@@ -595,6 +647,35 @@ function handle_read_resource(ctx::RequestContext, params::ReadResourceParams)::
     end
 
     if isnothing(resource)
+        # No exact match: route through resource templates (RFC 6570 level-1
+        # {var} segments). First matching template with a provider serves the read.
+        for tmpl in ctx.server.resource_templates
+            tmpl.data_provider === nothing && continue
+            vars = match_uri_template(tmpl.uri_template, params.uri)
+            vars === nothing && continue
+            return try
+                provider = tmpl.data_provider
+                # Providers may opt into a two-arg form to receive the extracted
+                # template variables (dispatch by applicability, like tool handlers)
+                data = applicable(provider, params.uri, vars) ?
+                       provider(params.uri, vars) : provider(params.uri)
+                contents = normalize_read_contents(
+                    data, params.uri, something(tmpl.mime_type, "application/json"))
+                HandlerResult(
+                    response = JSONRPCResponse(
+                        id = ctx.request_id,
+                        result = ReadResourceResult(contents = contents)
+                    )
+                )
+            catch e
+                HandlerResult(
+                    error=ErrorInfo(
+                        code=ErrorCodes.INTERNAL_ERROR,
+                        message="Error reading resource: $(e)"
+                    )
+                )
+            end
+        end
         return HandlerResult(
             error=ErrorInfo(
                 code=ErrorCodes.RESOURCE_NOT_FOUND,
@@ -605,27 +686,7 @@ function handle_read_resource(ctx::RequestContext, params::ReadResourceParams)::
 
     try
         data = resource.data_provider()
-
-        # Normalize the provider's return value into spec contents entries:
-        # - TextResourceContents/BlobResourceContents (or a vector of them)
-        #   serialize directly — the only path that can produce binary `blob`
-        #   contents. Dispatch is on the two concrete spec types, so a custom
-        #   ResourceContents subtype falls through to the JSON fallback instead
-        #   of erroring inside serialize_resource_contents.
-        # - a String becomes the text verbatim (with the resource's mime type)
-        # - anything else keeps the JSON-encoded fallback
-        wire_contents = Union{TextResourceContents,BlobResourceContents}
-        contents = if data isa wire_contents
-            [serialize_resource_contents(data)]
-        elseif data isa Vector && !isempty(data) && all(x -> x isa wire_contents, data)
-            [serialize_resource_contents(x) for x in data]
-        else
-            [LittleDict{String,Any}(
-                "uri" => string(resource.uri),
-                "text" => data isa AbstractString ? String(data) : JSON3.write(data),
-                "mimeType" => resource.mime_type
-            )]
-        end
+        contents = normalize_read_contents(data, string(resource.uri), resource.mime_type)
 
         # Use the proper ReadResourceResult struct
         HandlerResult(
@@ -643,6 +704,36 @@ function handle_read_resource(ctx::RequestContext, params::ReadResourceParams)::
             )
         )
     end
+end
+
+"""
+    handle_list_resource_templates(ctx::RequestContext, params::ListResourceTemplatesParams)
+        -> HandlerResult
+
+Handle a `resources/templates/list` request: advertise the server's resource templates
+in the spec wire shape (`resourceTemplates` entries with `uriTemplate`, `name`, and
+optional `description`/`mimeType`/`title`/`icons`/`_meta`).
+"""
+function handle_list_resource_templates(ctx::RequestContext,
+                                        params::ListResourceTemplatesParams)::HandlerResult
+    templates = map(ctx.server.resource_templates) do t
+        d = LittleDict{String,Any}(
+            "uriTemplate" => t.uri_template,
+            "name" => t.name
+        )
+        isempty(t.description) || (d["description"] = t.description)
+        t.mime_type !== nothing && (d["mimeType"] = t.mime_type)
+        t.title !== nothing && (d["title"] = t.title)
+        t.icons !== nothing && (d["icons"] = [icon_to_dict(i) for i in t.icons])
+        t._meta !== nothing && (d["_meta"] = t._meta)
+        d
+    end
+    HandlerResult(
+        response = JSONRPCResponse(
+            id = ctx.request_id,
+            result = LittleDict{String,Any}("resourceTemplates" => templates)
+        )
+    )
 end
 
 """
@@ -1273,6 +1364,10 @@ function handle_request(server::Server, state::ServerState, request::Request;
                 handle_list_resources(ctx, params)
             elseif request.method == "resources/read"
                 handle_read_resource(ctx, request.params::ReadResourceParams)
+            elseif request.method == "resources/templates/list"
+                # Handle null params (cursor is optional)
+                params = isnothing(request.params) ? ListResourceTemplatesParams() : request.params::ListResourceTemplatesParams
+                handle_list_resource_templates(ctx, params)
             elseif request.method == "tools/call"
                 handle_call_tool(ctx, request.params::CallToolParams)
             elseif request.method == "tools/list"

--- a/src/protocol/handlers.jl
+++ b/src/protocol/handlers.jl
@@ -168,6 +168,11 @@ _regex_escape(s::AbstractString) =
 Match `uri` against an RFC 6570 level-1 URI template. Each `{var}` placeholder matches
 one path segment (one or more characters excluding `/`). Returns the extracted
 variables on a full match, `nothing` otherwise.
+
+Deliberate subset of RFC 6570: variable names are `[A-Za-z0-9_]+` (no dotted or
+pct-encoded names); adjacent placeholders with no literal between them (`{a}{b}`) are
+ambiguous and never match; a repeated variable name must capture the same value in
+every position.
 """
 function match_uri_template(template::String, uri::String)::Union{Nothing,Dict{String,String}}
     names = String[]
@@ -175,6 +180,10 @@ function match_uri_template(template::String, uri::String)::Union{Nothing,Dict{S
     print(pattern, "^")
     pos = 1
     for m in eachmatch(r"\{([A-Za-z0-9_]+)\}", template)
+        # Adjacent placeholders ({a}{b}) have no separator to split the captures
+        # on — ambiguous extraction and a regex-backtracking hazard on
+        # client-controlled URIs. Treat the template as unmatchable.
+        m.offset == pos && !isempty(names) && return nothing
         print(pattern, _regex_escape(template[pos:prevind(template, m.offset)]))
         push!(names, String(m.captures[1]))
         print(pattern, "([^/]+)")
@@ -183,7 +192,14 @@ function match_uri_template(template::String, uri::String)::Union{Nothing,Dict{S
     print(pattern, _regex_escape(template[pos:end]), "\$")
     mm = match(Regex(String(take!(pattern))), uri)
     mm === nothing && return nothing
-    Dict{String,String}(n => String(c) for (n, c) in zip(names, mm.captures))
+    vars = Dict{String,String}()
+    for (n, c) in zip(names, mm.captures)
+        v = String(c)
+        # A repeated variable name must capture one consistent value
+        haskey(vars, n) && vars[n] != v && return nothing
+        vars[n] = v
+    end
+    vars
 end
 
 """

--- a/src/protocol/jsonrpc.jl
+++ b/src/protocol/jsonrpc.jl
@@ -4,6 +4,7 @@ const REQUEST_PARAMS_MAP = Dict{String,Type}(
     "initialize" => InitializeParams,
     "resources/list" => ListResourcesParams,
     "resources/read" => ReadResourceParams,
+    "resources/templates/list" => ListResourceTemplatesParams,
     "tools/call" => CallToolParams,
     "tools/list" => ListToolsParams,
     "prompts/list" => ListPromptsParams,

--- a/src/protocol/messages.jl
+++ b/src/protocol/messages.jl
@@ -211,6 +211,18 @@ Base.@kwdef struct CallToolResult <: ResponseResult
     _meta::Union{Nothing,AbstractDict} = nothing
 end
 
+"""
+    ListResourceTemplatesParams(; cursor::Union{String,Nothing}=nothing) <: RequestParams
+
+Parameters for a `resources/templates/list` request.
+
+# Fields
+- `cursor::Union{String,Nothing}`: Optional pagination cursor for long template lists
+"""
+Base.@kwdef struct ListResourceTemplatesParams <: RequestParams
+    cursor::Union{String,Nothing} = nothing
+end
+
 #= Task-Related Messages (MCP Tasks, SEP-1686, experimental) =#
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -589,17 +589,29 @@ end
     ResourceTemplate(; name::String, uri_template::String,
                    mime_type::Union{String,Nothing}=nothing, description::String="",
                    title::Union{String,Nothing}=nothing,
-                   icons::Union{Vector{MCPIcon},Nothing}=nothing)
+                   icons::Union{Vector{MCPIcon},Nothing}=nothing,
+                   data_provider::Union{Function,Nothing}=nothing,
+                   _meta::Union{Nothing,Dict{String,Any}}=nothing)
 
-Define a template for dynamically generating resources with parameterized URIs.
+Define a parameterized family of resources: an RFC 6570 URI template (level-1 `{var}`
+placeholders, advertised via `resources/templates/list`) plus a provider that serves
+any `resources/read` whose URI matches the template.
 
 # Fields
 - `name::String`: Name of the resource template
-- `uri_template::String`: Template string with placeholders for parameters
-- `mime_type::Union{String,Nothing}`: MIME type of the generated resources
+- `uri_template::String`: URI template with `{var}` placeholders; each placeholder
+  matches one path segment (no `/`)
+- `mime_type::Union{String,Nothing}`: MIME type shared by all matching resources
 - `description::String`: Human-readable description of the template
 - `title::Union{String,Nothing}`: Optional human-friendly display name
 - `icons::Union{Vector{MCPIcon},Nothing}`: Optional icons for UI display
+- `data_provider::Union{Function,Nothing}`: Called for a matching `resources/read` as
+  `provider(uri::String)` — or opt into `provider(uri::String, vars::Dict{String,String})`
+  to receive the extracted template variables. Return values follow the same contract as
+  `MCPResource` providers (`ResourceContents`/vector, `String` verbatim, JSON fallback).
+  Templates without a provider are advertised but not readable.
+- `_meta::Union{Nothing,Dict{String,Any}}`: Optional metadata for protocol extensions,
+  emitted verbatim in `resources/templates/list` when set
 """
 Base.@kwdef struct ResourceTemplate
     name::String
@@ -608,6 +620,8 @@ Base.@kwdef struct ResourceTemplate
     description::String = ""
     title::Union{String,Nothing} = nothing
     icons::Union{Vector{MCPIcon},Nothing} = nothing
+    data_provider::Union{Function,Nothing} = nothing  # provider(uri) or provider(uri, vars); see resources/read routing
+    _meta::Union{Nothing,Dict{String,Any}} = nothing  # emitted verbatim in resources/templates/list when set
 end
 
 #==============================================================================

--- a/src/types.jl
+++ b/src/types.jl
@@ -624,6 +624,12 @@ Base.@kwdef struct ResourceTemplate
     _meta::Union{Nothing,Dict{String,Any}} = nothing  # emitted verbatim in resources/templates/list when set
 end
 
+# Back-compat: the pre-0.5.4 six-field positional shape still constructs
+ResourceTemplate(name::String, uri_template::String, mime_type::Union{String,Nothing},
+                 description::String, title::Union{String,Nothing},
+                 icons::Union{Vector{MCPIcon},Nothing}) =
+    ResourceTemplate(name, uri_template, mime_type, description, title, icons, nothing, nothing)
+
 #==============================================================================
 # 7. Subscription and Progress Types
 ==============================================================================#

--- a/test/e2e/fixtures/wire_demo_server.jl
+++ b/test/e2e/fixtures/wire_demo_server.jl
@@ -92,6 +92,16 @@ res_text = MCPResource(
     data_provider = () -> "plain, not JSON-quoted",
 )
 
+tmpl_artifact = ResourceTemplate(
+    name = "artifact",
+    uri_template = "demo://artifact/{id}",
+    description = "Content-addressed artifact family (URI template demo)",
+    mime_type = "image/png",
+    data_provider = (uri, vars) -> BlobResourceContents(
+        uri = uri, mime_type = "image/png",
+        blob = vcat(png_bytes, Vector{UInt8}(vars["id"]))),
+)
+
 server = mcp_server(
     name = "wire-demo",
     version = "0.1.0",
@@ -99,6 +109,7 @@ server = mcp_server(
     tools = [analyze, structured, count_slow],
     prompts = [media_prompt],
     resources = [res, res_blob, res_text],
+    resource_templates = [tmpl_artifact],
 )
 
 if "http" in ARGS

--- a/test/e2e/test_wire_conformance.jl
+++ b/test/e2e/test_wire_conformance.jl
@@ -20,9 +20,11 @@ const _WIRE_REQUESTS = [
     """{"jsonrpc":"2.0","method":"resources/list","params":{},"id":6}""",
     """{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"demo://logo"},"id":7}""",
     """{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"demo://readme"},"id":8}""",
+    """{"jsonrpc":"2.0","method":"resources/templates/list","params":{},"id":9}""",
+    """{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"demo://artifact/ab12"},"id":10}""",
 ]
 
-# Shared assertions on the eight responses (Dict id => parsed JSON3 object),
+# Shared assertions on the ten responses (Dict id => parsed JSON3 object),
 # used by both the stdio and HTTP passes.
 function _wire_assert(resp)
     # 1: initialize — negotiated version + serverInfo.description
@@ -78,6 +80,18 @@ function _wire_assert(resp)
     # 8: String provider data is the text verbatim (not JSON-quoted)
     @test resp[8].result.contents[1].text == "plain, not JSON-quoted"
     @test resp[8].result.contents[1].mimeType == "text/plain"
+
+    # 9: resources/templates/list — spec wire keys
+    t = only(resp[9].result.resourceTemplates)
+    @test t.uriTemplate == "demo://artifact/{id}"
+    @test t.name == "artifact"
+    @test t.mimeType == "image/png"
+
+    # 10: templated read — provider received the uri + extracted {id}
+    art = resp[10].result.contents[1]
+    @test art.uri == "demo://artifact/ab12"
+    @test art.blob == base64encode(vcat(UInt8[0x89, 0x50, 0x4E, 0x47], Vector{UInt8}("ab12")))
+    @test art.mimeType == "image/png"
 end
 
 @testset "E2E wire conformance (real subprocesses)" begin
@@ -93,8 +107,8 @@ end
             msg = JSON3.read(line)
             haskey(msg, :id) && (resp[msg.id] = msg)
         end
-        @test length(resp) == 8
-        length(resp) == 8 && _wire_assert(resp)
+        @test length(resp) == 10
+        length(resp) == 10 && _wire_assert(resp)
     end
 
     @testset "stdio logging/setLevel takes effect live" begin
@@ -159,8 +173,8 @@ end
                     # The response HEADER echoes the NEGOTIATED version on every
                     # response (client asked 2025-06-18; transport default is latest)
                     @test all(==("2025-06-18"), versions)
-                    @test length(resp) == 8
-                    length(resp) == 8 && _wire_assert(resp)
+                    @test length(resp) == 10
+                    length(resp) == 10 && _wire_assert(resp)
                 end
             finally
                 kill(proc)

--- a/test/features/resources.jl
+++ b/test/features/resources.jl
@@ -111,6 +111,9 @@
         @test match_uri_template("a://r/{id}", "a://r/x/y") === nothing   # {var} won't cross '/'
         @test match_uri_template("a://r/{id}", "b://r/x") === nothing
         @test match_uri_template("a://r.x/{id}", "a://rqx/1") === nothing # literal '.' escaped
+        @test match_uri_template("a://{a}{b}", "a://xy") === nothing      # adjacent vars: ambiguous, never match
+        @test match_uri_template("a://{id}/{id}", "a://x/x") == Dict("id" => "x")  # repeats must agree
+        @test match_uri_template("a://{id}/{id}", "a://x/y") === nothing
 
         png = UInt8[0x89, 0x50, 0x4E, 0x47]
         tmpl = ResourceTemplate(
@@ -175,6 +178,10 @@
         register!(server, boom)
         r = handle_read_resource(ctx, ReadResourceParams(uri = "test://boom/1"))
         @test r.error.code == Int(ModelContextProtocol.ErrorCodes.INTERNAL_ERROR)
+
+        # pre-0.5.4 six-field positional construction still works
+        legacy = ResourceTemplate("legacy", "test://l/{x}", "text/plain", "d", nothing, nothing)
+        @test legacy.data_provider === nothing && legacy._meta === nothing
     end
 
     @testset "resources/read unknown URI is a resource error" begin

--- a/test/features/resources.jl
+++ b/test/features/resources.jl
@@ -104,6 +104,79 @@
         @test c["mimeType"] == "text/plain"
     end
 
+    @testset "resource templates: matching, listing, read routing" begin
+        # match_uri_template semantics
+        @test match_uri_template("a://r/{id}", "a://r/x1") == Dict("id" => "x1")
+        @test match_uri_template("a://{p}/{q}.png", "a://u/v.png") == Dict("p" => "u", "q" => "v")
+        @test match_uri_template("a://r/{id}", "a://r/x/y") === nothing   # {var} won't cross '/'
+        @test match_uri_template("a://r/{id}", "b://r/x") === nothing
+        @test match_uri_template("a://r.x/{id}", "a://rqx/1") === nothing # literal '.' escaped
+
+        png = UInt8[0x89, 0x50, 0x4E, 0x47]
+        tmpl = ResourceTemplate(
+            name = "artifact",
+            uri_template = "test://artifact/{id}",
+            description = "Content-addressed artifacts",
+            mime_type = "image/png",
+            data_provider = (uri, vars) -> BlobResourceContents(
+                uri = uri, mime_type = "image/png",
+                blob = vcat(png, Vector{UInt8}(vars["id"]))),
+        )
+        one_arg = ResourceTemplate(
+            name = "echo",
+            uri_template = "test://echo/{word}",
+            mime_type = "text/plain",
+            data_provider = uri -> "got: $uri",
+        )
+        bare = ResourceTemplate(name = "no-provider", uri_template = "test://bare/{x}")
+        exact = MCPResource(uri = "test://artifact/special", name = "special",
+                            mime_type = "text/plain", data_provider = () -> "exact wins")
+
+        server = mcp_server(name = "test", version = "1.0.0",
+                            resources = [exact],
+                            resource_templates = [tmpl, one_arg, bare])
+        ctx = RequestContext(server = server, request_id = 1)
+
+        # templates/list wire shape
+        lst = handle_list_resource_templates(ctx, ListResourceTemplatesParams())
+        entries = lst.response.result["resourceTemplates"]
+        @test length(entries) == 3
+        e1 = only(filter(e -> e["name"] == "artifact", entries))
+        @test e1["uriTemplate"] == "test://artifact/{id}"
+        @test e1["mimeType"] == "image/png"
+        @test e1["description"] == "Content-addressed artifacts"
+
+        # two-arg provider receives extracted vars; blob through template
+        c = handle_read_resource(ctx, ReadResourceParams(uri = "test://artifact/ab12")).response.result.contents[1]
+        @test c["blob"] == base64encode(vcat(png, Vector{UInt8}("ab12")))
+        @test c["uri"] == "test://artifact/ab12"
+        @test c["mimeType"] == "image/png"
+
+        # one-arg provider receives the requested uri; String verbatim
+        c = handle_read_resource(ctx, ReadResourceParams(uri = "test://echo/hi")).response.result.contents[1]
+        @test c["text"] == "got: test://echo/hi"
+        @test c["mimeType"] == "text/plain"
+
+        # exact-URI resources take precedence over matching templates
+        c = handle_read_resource(ctx, ReadResourceParams(uri = "test://artifact/special")).response.result.contents[1]
+        @test c["text"] == "exact wins"
+
+        # provider-less templates are advertised but not readable
+        r = handle_read_resource(ctx, ReadResourceParams(uri = "test://bare/zzz"))
+        @test r.error.code == Int(ModelContextProtocol.ErrorCodes.RESOURCE_NOT_FOUND)
+
+        # non-matching URIs still 404
+        r = handle_read_resource(ctx, ReadResourceParams(uri = "test://nope/1"))
+        @test r.error.code == Int(ModelContextProtocol.ErrorCodes.RESOURCE_NOT_FOUND)
+
+        # provider errors surface as internal errors, not throws
+        boom = ResourceTemplate(name = "boom", uri_template = "test://boom/{x}",
+                                data_provider = uri -> error("nope"))
+        register!(server, boom)
+        r = handle_read_resource(ctx, ReadResourceParams(uri = "test://boom/1"))
+        @test r.error.code == Int(ModelContextProtocol.ErrorCodes.INTERNAL_ERROR)
+    end
+
     @testset "resources/read unknown URI is a resource error" begin
         server = mcp_server(name = "test", version = "1.0.0")
         ctx = RequestContext(server = server, request_id = 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,8 @@ using ModelContextProtocol: WELL_KNOWN_PATH, handle_well_known_request  # For pr
 using ModelContextProtocol: TaskStore, TaskRecord, TaskCapability, create_task!, get_task,
     finish_task!, cancel_task!, task_wire, task_is_terminal,
     encode_task_cursor, decode_task_cursor  # For MCP Tasks tests
+using ModelContextProtocol: match_uri_template, handle_list_resource_templates,
+    ListResourceTemplatesParams  # For resource template tests
 
 # End-to-end tests spawn the example servers as real subprocesses (slow JIT
 # startup), so they run locally by default and are skipped on CI. Force either


### PR DESCRIPTION
Closes #63 — the follow-up aimg asked for after #62 (*"our artifacts ARE a content-addressed namespace, so URI templating is the clean long-term fit"*). Folded into the **unreleased 0.5.4** alongside #59 per release-batching: one registration with the complete resource story instead of two patches in a day.

## What it adds

- `ResourceTemplate` gains a `data_provider` (and `_meta`); the previously metadata-only stub becomes functional
- **Read routing**: `resources/read` with no exact-URI match routes through registered templates — RFC 6570 level-1 `{var}` placeholders (one path segment each), first matching template with a provider serves the read, exact-URI resources always take precedence
- **Provider contract**: `provider(uri)` — or opt into `provider(uri, vars)` for the extracted placeholder values (`applicable`-based dispatch, same pattern as tool handlers). Returns share the #62 contract (`ResourceContents`/vector incl. binary blob, `String` verbatim, JSON fallback) via the extracted `normalize_read_contents` helper
- **`resources/templates/list`** in the spec wire shape (`uriTemplate`, `name`, optional `description`/`mimeType`/`title`/`icons`/`_meta`)
- Registration via `mcp_server(resource_templates = …)` or `register!(server, template)`

aimg's target shape works directly:

```julia
ResourceTemplate(
    name = "artifact",
    uri_template = "aimg://result/{id}",
    mime_type = "image/png",
    data_provider = (uri, vars) -> BlobResourceContents(
        uri = uri, mime_type = "image/png", blob = workspace_lookup(vars["id"]))
)
```

## Verification

- Suite **861/861** (was 829): template matching semantics (segment boundaries, literal escaping, multi-var), routing precedence, one-arg vs two-arg providers, provider-less templates advertised-but-404, provider errors → `-32603`
- Wire-conformance e2e over **both transports**: `resources/templates/list` spec keys + a templated read returning a blob built from the extracted `{id}`
- Local Documenter build green

## Compatibility

Additive: new optional fields on `ResourceTemplate` (kwdef defaults), new kwarg, new method route. No behavior change for servers without templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)